### PR TITLE
Define write operations for status page API

### DIFF
--- a/docs/component_overview.md
+++ b/docs/component_overview.md
@@ -47,7 +47,7 @@ C4Component
   }
 
   Container_Boundary(components, "Components") {
-    Component(component, Component, "ID, displayName, Labels, affectedBy")
+    Component(component, Component, "ID, displayName, Labels, activelyAffectedBy")
     Component(labels, Labels, "", "Key value pairs")
 
     Rel(component, labels, "contains")
@@ -63,16 +63,16 @@ C4Component
 
   %% new %%
   Rel(incident, impactList, "affects")
-  Rel(component, impactList, "affected by")
+  Rel(component, impactList, "actively affected by", "only list active/open impacts")
   Rel(incident, phaseReference, "has")
   Rel(impact, component, "references", "from Incident")
   Rel(impact, incident, "references", "from Component")
 
   UpdateRelStyle(incident, impactList, "green", "green")
-  UpdateRelStyle(component, impactList, "green", "green")
+  UpdateRelStyle(component, impactList, "green", "green", $offsetY="70")
   UpdateRelStyle(incident, phaseReference, "green", "green")
-  UpdateRelStyle(impact, component, "green", "green")
-  UpdateRelStyle(impact, incident, "green", "green")
+  UpdateRelStyle(impact, component, "green", "green", $offsetX="-140")
+  UpdateRelStyle(impact, incident, "green", "green", $offsetX="-100")
 
 ```
 

--- a/docs/component_overview.md
+++ b/docs/component_overview.md
@@ -9,16 +9,20 @@ C4Component
   Container_Boundary(impacts, "Impacts") {
     Component(impactType, ImpactType, "ID, displayName, description")
     Component(impact, Impact, "type, reference")
-    Component(impactList, ImpactList, "[]Impact")
+    Component(impactComponentList, ImpactComponentList, "[]Impact", "Impacts reference components")
+    Component(impactIncidentList, ImpactIncidentList, "<<readonly>>[]Impact", "Impacts reference incidents")
 
     Rel(impact, impactType, "has")
-    Rel(impactList, impact, "lists")
+    Rel(impactComponentList, impact, "lists")
+    Rel(impactIncidentList, impact, "lists")
 
     UpdateElementStyle(impact, $bgColor="green")
-    UpdateElementStyle(impactList, $bgColor="green")
+    UpdateElementStyle(impactComponentList, $bgColor="green")
+    UpdateElementStyle(impactIncidentList, $bgColor="green")
 
     UpdateRelStyle(impact, impactType, "green", "green", $offsetY="-10")
-    UpdateRelStyle(impactList, impact, "green", "green", $offsetY="-10")
+    UpdateRelStyle(impactComponentList, impact, "green", "green", $offsetY="-15")
+    UpdateRelStyle(impactIncidentList, impact, "green", "green")
   }
 
   Container_Boundary(incidents, "Incidents") {
@@ -62,15 +66,15 @@ C4Component
   UpdateRelStyle(component, incident, "red", "red", $offsetX="10")
 
   %% new %%
-  Rel(incident, impactList, "affects")
-  Rel(component, impactList, "actively affected by", "only list active/open impacts")
+  Rel(incident, impactComponentList, "affects")
+  Rel(component, impactIncidentList, "actively affected by", "only list active/open impacts")
   Rel(incident, phaseReference, "has")
-  Rel(impact, component, "references", "from Incident")
-  Rel(impact, incident, "references", "from Component")
+  Rel(impact, component, "references", "from impactComponentList")
+  Rel(impact, incident, "references", "from impactIncidentList")
 
-  UpdateRelStyle(incident, impactList, "green", "green")
-  UpdateRelStyle(component, impactList, "green", "green", $offsetY="70")
-  UpdateRelStyle(incident, phaseReference, "green", "green")
+  UpdateRelStyle(incident, impactComponentList, "green", "green")
+  UpdateRelStyle(component, impactIncidentList, "green", "green", $offsetX="-180", $offsetY="-70")
+  UpdateRelStyle(incident, phaseReference, "green", "green", $offsetX="-70", $offsetY="40")
   UpdateRelStyle(impact, component, "green", "green", $offsetX="-140")
   UpdateRelStyle(impact, incident, "green", "green", $offsetX="-100")
 

--- a/docs/component_overview.md
+++ b/docs/component_overview.md
@@ -1,6 +1,6 @@
 # Component Overview
 
-This represents a part of the decission process related to the overall structure the API wants to represent.
+This represents a part of the decision process related to the overall structure the API wants to represent.
 
 ```mermaid
 C4Component

--- a/docs/component_overview.md
+++ b/docs/component_overview.md
@@ -1,0 +1,83 @@
+# Component Overview
+
+This represents a part of the decission process related to the overall structure the API wants to represent.
+
+```mermaid
+C4Component
+  title status-page-openapi
+
+  Container_Boundary(impacts, "Impacts") {
+    Component(impactType, ImpactType, "ID, displayName, description")
+    Component(impact, Impact, "type, reference")
+    Component(impactList, ImpactList, "[]Impact")
+
+    Rel(impact, impactType, "has")
+    Rel(impactList, impact, "lists")
+
+    UpdateElementStyle(impact, $bgColor="green")
+    UpdateElementStyle(impactList, $bgColor="green")
+
+    UpdateRelStyle(impact, impactType, "green", "green", $offsetY="-10")
+    UpdateRelStyle(impactList, impact, "green", "green", $offsetY="-10")
+  }
+
+  Container_Boundary(incidents, "Incidents") {
+    Component(incidentUpdate, IncidentUpdate, "order, displayName, description, createdAt")
+    Component(incident, Incident, "ID, displayName, description, updates, affects, beganAt, endedAt, Phase")
+
+    Rel(incident, incidentUpdate, "contains")
+  }
+
+  Container_Boundary(phases, "Phases") {
+    Component(phaseReference, PhaseReference, "Phase, order, generation")
+    Component(phase, Phase, "", "it is just a name")
+    Component(phaseList, PhaseList, "generation, []Phase")
+
+    Rel(phaseList, phase, "lists")
+    Rel(phaseReference, phase, "references")
+    Rel(phaseReference, phaseList, "references")
+
+    UpdateElementStyle(phaseReference, $bgColor="green")
+    UpdateElementStyle(phaseList, $bgColor="green")
+
+    UpdateRelStyle(phaseList, phase, "green", "green", $offsetY="5")
+    UpdateRelStyle(phaseReference, phase, "green", "green", $offsetX="-30", $offsetY="10")
+    UpdateRelStyle(phaseReference, phaseList, "green", "green", $offsetY="5")
+
+  }
+
+  Container_Boundary(components, "Components") {
+    Component(component, Component, "ID, displayName, Labels, affectedBy")
+    Component(labels, Labels, "", "Key value pairs")
+
+    Rel(component, labels, "contains")
+  }
+
+  %% global relations %%
+  %% deprecated %%
+  Rel(incident, impactType, "has")
+  BiRel(component, incident, "affects / affected by")
+
+  UpdateRelStyle(incident, impactType, "red", "red")
+  UpdateRelStyle(component, incident, "red", "red", $offsetX="10")
+
+  %% new %%
+  Rel(incident, impactList, "affects")
+  Rel(component, impactList, "affected by")
+  Rel(incident, phaseReference, "has")
+  Rel(impact, component, "references", "from Incident")
+  Rel(impact, incident, "references", "from Component")
+
+  UpdateRelStyle(incident, impactList, "green", "green")
+  UpdateRelStyle(component, impactList, "green", "green")
+  UpdateRelStyle(incident, phaseReference, "green", "green")
+  UpdateRelStyle(impact, component, "green", "green")
+  UpdateRelStyle(impact, incident, "green", "green")
+
+```
+
+Color meaning:
+
+- Blue: Existing structure
+- Red: Deprecated / removed
+- Green: New

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -36,6 +36,10 @@ components:
       format: date-time
       nullable: true
 
+    Success:
+      description: An operation was successful.
+      type: boolean
+
     # API objects
     ImpactType:
       type: object
@@ -166,6 +170,18 @@ components:
       required:
         - id
 
+    ResponseData:
+      description: |
+        Wraps the retuned data in an object.
+        See: https://github.com/SovereignCloudStack/status-page-openapi/issues/6
+      type: object
+      properties:
+        content:
+          oneOf:
+            - $ref: '#/components/schemas/Success'
+            - $ref: '#/components/schemas/Id'
+            - $ref: '#/components/schemas/Incremental'
+
   # requests
   requestBodies:
     ComponentRequest:
@@ -198,26 +214,12 @@ components:
 
   # responses
   responses:
-    SuccessResponse:
-      description: A request has successfully run.
+    Response:
+      description: General response for successful operations.
       content:
         application/json:
           schema:
-            type: boolean
-
-    IdResponse:
-      description: A request returns an ID.
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Id'
-
-    IncrementalResponse:
-      description: A request returns an Incremental.
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Incremental'
+            $ref: '#/components/schemas/ResponseData'
 
   # parameter
   parameters:
@@ -281,7 +283,7 @@ paths:
               $ref: '#/components/schemas/PhaseList'
       responses:
         '201':
-          $ref: '#/components/responses/IncrementalResponse'
+          $ref: '#/components/responses/Response'
 
   /impacttypes:
     get:
@@ -304,7 +306,7 @@ paths:
         $ref: '#/components/requestBodies/ImpactTypeRequest'
       responses:
         '201':
-          $ref: '#/components/responses/IdResponse'
+          $ref: '#/components/responses/Response'
 
   /impacttypes/{impactTypeId}:
     get:
@@ -329,7 +331,7 @@ paths:
         $ref: '#/components/requestBodies/ImpactTypeRequest'
       responses:
         '200':
-          $ref: '#/components/responses/SuccessResponse'
+          $ref: '#/components/responses/Response'
 
     delete:
       summary: Delete an impact type.
@@ -338,7 +340,7 @@ paths:
         - $ref: '#/components/parameters/ImpactTypeIdPathParameter'
       responses:
         '200':
-          $ref: "#/components/responses/SuccessResponse"
+          $ref: "#/components/responses/Response"
 
   /components:
     get:
@@ -361,7 +363,7 @@ paths:
         $ref: '#/components/requestBodies/ComponentRequest'
       responses:
         '201':
-          $ref: '#/components/responses/IdResponse'
+          $ref: '#/components/responses/Response'
 
   /components/{componentId}:
     get:
@@ -371,7 +373,7 @@ paths:
       - $ref: '#/components/parameters/ComponentIdPathParameter'
       responses:
         '200':
-          $ref: '#/components/responses/IdResponse'
+          $ref: '#/components/responses/Response'
 
     patch:
       summary: Update a component.
@@ -382,7 +384,7 @@ paths:
         $ref: '#/components/requestBodies/ComponentRequest'
       responses:
         '200':
-          $ref: "#/components/responses/SuccessResponse"
+          $ref: "#/components/responses/Response"
 
     delete:
       summary: Delete a component.
@@ -391,7 +393,7 @@ paths:
         - $ref: '#/components/parameters/ComponentIdPathParameter'
       responses:
         '200':
-          $ref: "#/components/responses/SuccessResponse"
+          $ref: "#/components/responses/Response"
 
   /incidents:
     get:
@@ -431,7 +433,7 @@ paths:
         $ref: '#/components/requestBodies/IncidentRequest'
       responses:
         '201':
-          $ref: '#/components/responses/IdResponse'
+          $ref: '#/components/responses/Response'
 
   /incidents/{incidentId}:
     get:
@@ -456,7 +458,7 @@ paths:
         $ref: '#/components/requestBodies/IncidentRequest'
       responses:
         '200':
-          $ref: "#/components/responses/SuccessResponse"
+          $ref: "#/components/responses/Response"
 
     delete:
       summary: Delete an incident.
@@ -465,7 +467,7 @@ paths:
         - $ref: '#/components/parameters/IncidentIdPathParameter'
       responses:
         '200':
-          $ref: "#/components/responses/SuccessResponse"
+          $ref: "#/components/responses/Response"
 
   /incidents/{incidentId}/updates:
     get:
@@ -492,7 +494,7 @@ paths:
         $ref: '#/components/requestBodies/IncidentUpdateRequest'
       responses:
         '201':
-          $ref: '#/components/responses/IdResponse'
+          $ref: '#/components/responses/Response'
 
   /incidents/{incidentId}/updates/{updateId}:
     get:
@@ -519,7 +521,7 @@ paths:
         $ref: '#/components/requestBodies/IncidentUpdateRequest'
       responses:
         '200':
-          $ref: "#/components/responses/SuccessResponse"
+          $ref: "#/components/responses/Response"
 
     delete:
       summary: Delete a specific update from a specific incident
@@ -529,4 +531,4 @@ paths:
         - $ref: '#/components/parameters/IncidentUpdateIdPathParameter'
       responses:
         '200':
-          $ref: "#/components/responses/SuccessResponse"
+          $ref: "#/components/responses/Response"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -150,7 +150,11 @@ components:
         description:
           $ref: '#/components/schemas/Description'
         updates:
-          $ref: '#/components/schemas/Incremental'
+          description: An incident will have multiple references to updates and they should not be changed.
+          type: array
+          readOnly: true
+          items:
+            $ref: '#/components/schemas/Incremental'
         affects:
           $ref: '#/components/schemas/ImpactList'
         beganAt:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -118,7 +118,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/IncidentImpactType'
-  /impacttype:
     post:
       summary: Create a new impact type
       operationId: createImpactType
@@ -134,23 +133,6 @@ paths:
             application/json:
               schema:
                 type: string
-  /component/{componentId}:
-    get:
-      summary: get specific component by id
-      operationId: getComponent
-      parameters:
-      - in: path
-        name: componentId
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Component'
   /components:
     get:
       responses:
@@ -162,7 +144,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Component'
-  /component:
     post:
       summary: Create a new component
       operationId: createComponent
@@ -178,13 +159,13 @@ paths:
             application/json:
               schema:
                 type: string
-  /incident/{incidentId}:
+  /components/{componentId}:
     get:
-      summary: Get specific incident by id
-      operationId: getIncident
+      summary: Get specific component by id
+      operationId: getComponent
       parameters:
       - in: path
-        name: incidentId
+        name: componentId
         required: true
         schema:
           type: string
@@ -194,7 +175,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Incident'
+                $ref: '#/components/schemas/Component'
   /incidents:
     get:
       summary: Get list of incidents
@@ -224,9 +205,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Incident'
-  /incident:
     post:
-      summary: create a new incident
+      summary: Create a new incident
       operationId: createIncident
       requestBody:
         content:
@@ -240,3 +220,20 @@ paths:
             application/json:
               schema:
                 type: string
+  /incidents/{incidentId}:
+    get:
+      summary: Get specific incident by id
+      operationId: getIncident
+      parameters:
+      - in: path
+        name: incidentId
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Incident'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -198,8 +198,56 @@ components:
         $ref: '#/components/schemas/Incident'
       readOnly: true
 
+  # parameter
+  parameters:
+    GenerationQueryParameter:
+      description: Optional generation in query. E.g. ?generation=7
+      name: generation
+      in: query
+      schema:
+        $ref: '#/components/schemas/Incremental'
+
+    ComponentIdPathParameter:
+      description: Component ID is required in path.
+      name: componentId
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/Id'
+
+    IncidentIdPathParameter:
+      description: Incident ID is required in path.
+      name: incidentId
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/Id'
+
+    IncidentUpdateIdPathParameter:
+      description: Incident update id (inremental) is required in path.
+      name: updateId
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/Incremental'
+
+    ImpactTypeIdPathParameter:
+      description: Impact type ID is required in path.
+      name: impactTypeId
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/Id'
+
   # requests
   requestBodies:
+    PhaseListRequest:
+      description: Send a new list of phases.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PhaseList'
+
     ComponentRequest:
       description: Send a component.
       content:
@@ -350,50 +398,13 @@ components:
               data:
                 $ref: '#/components/schemas/IncidentUpdateList'
 
-  # parameter
-  parameters:
-    ComponentIdPathParameter:
-      description: Component ID is required in path.
-      name: componentId
-      in: path
-      required: true
-      schema:
-        $ref: '#/components/schemas/Id'
-
-    IncidentIdPathParameter:
-      description: Incident ID is required in path.
-      name: incidentId
-      in: path
-      required: true
-      schema:
-        $ref: '#/components/schemas/Id'
-
-    IncidentUpdateIdPathParameter:
-      description: Incident update id (inremental) is required in path.
-      name: updateId
-      in: path
-      required: true
-      schema:
-        $ref: '#/components/schemas/Incremental'
-
-    ImpactTypeIdPathParameter:
-      description: Impact type ID is required in path.
-      name: impactTypeId
-      in: path
-      required: true
-      schema:
-        $ref: '#/components/schemas/Id'
-
 paths:
   /phases:
     get:
       summary: Get the current generation list of phases.
       operationId: getPhaseList
       parameters:
-        - name: generation
-          in: query
-          schema:
-            $ref: '#/components/schemas/Incremental'
+        - $ref: '#/components/parameters/GenerationQueryParameter'
       responses:
         '200':
           $ref: '#/components/responses/PhaseListResponse'
@@ -402,10 +413,7 @@ paths:
       summary: Create a new generation of the phase list.
       operationId: createPhaseList
       requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PhaseList'
+        $ref: '#/components/requestBodies/PhaseListRequest'
       responses:
         '201':
           $ref: '#/components/responses/IncrementalResponse'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15,11 +15,19 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/Id'
+      readOnly: true
 
     Incremental:
       description: |
         Positive and incrementing number for ordering and identfication of e.g. sub resources.
       type: integer
+      readOnly: true
+
+    IncrementalList:
+      description: List of Incrementals for referencing subresources.
+      type: array
+      items:
+        $ref: '#/components/schemas/Incremental'
       readOnly: true
 
     DisplayName:
@@ -52,6 +60,12 @@ components:
           $ref: '#/components/schemas/Description'
       required:
         - id
+
+    ImpactTypeList:
+      type: array
+      items:
+        $ref: '#/components/schemas/ImpactType'
+      readOnly: true
 
     Impact:
       description: An impact connects a component and an incident with an impact type.
@@ -124,6 +138,12 @@ components:
         - order
         - createdAt
 
+    IncidentUpdateList:
+      type: array
+      items:
+        $ref: '#/components/schemas/IncidentUpdate'
+      readOnly: true
+
     Labels:
       description: Labels are free text key value pairs for components.
       type: object
@@ -144,6 +164,12 @@ components:
       required:
         - id
 
+    ComponentList:
+      type: array
+      items:
+        $ref: '#/components/schemas/Component'
+      readOnly: true
+
     Incident:
       type: object
       properties:
@@ -154,11 +180,7 @@ components:
         description:
           $ref: '#/components/schemas/Description'
         updates:
-          description: An incident will have multiple references to updates and they should not be changed.
-          type: array
-          readOnly: true
-          items:
-            $ref: '#/components/schemas/Incremental'
+          $ref: '#/components/schemas/IncrementalList'
         affects:
           $ref: '#/components/schemas/ImpactList'
         beganAt:
@@ -169,6 +191,12 @@ components:
           $ref: '#/components/schemas/PhaseReference'
       required:
         - id
+
+    IncidentList:
+      type: array
+      items:
+        $ref: '#/components/schemas/Incident'
+      readOnly: true
 
     ResponseData:
       description: |
@@ -181,6 +209,15 @@ components:
             - $ref: '#/components/schemas/Success'
             - $ref: '#/components/schemas/Id'
             - $ref: '#/components/schemas/Incremental'
+            - $ref: '#/components/schemas/PhaseList'
+            - $ref: '#/components/schemas/ImpactType'
+            - $ref: '#/components/schemas/ImpactTypeList'
+            - $ref: '#/components/schemas/Component'
+            - $ref: '#/components/schemas/ComponentList'
+            - $ref: '#/components/schemas/Incident'
+            - $ref: '#/components/schemas/IncidentList'
+            - $ref: '#/components/schemas/IncidentUpdate'
+            - $ref: '#/components/schemas/IncidentUpdateList'
 
   # requests
   requestBodies:
@@ -267,11 +304,7 @@ paths:
             $ref: '#/components/schemas/Incremental'
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PhaseList'
+          $ref: '#/components/responses/Response'
 
     post:
       summary: Create a new generation of the phase list.
@@ -291,13 +324,7 @@ paths:
       operationId: getImpactTypes
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ImpactType'
+          $ref: '#/components/responses/Response'
 
     post:
       summary: Create a new impact type.
@@ -316,11 +343,7 @@ paths:
         - $ref: '#/components/parameters/ImpactTypeIdPathParameter'
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ImpactType'
+          $ref: '#/components/responses/Response'
 
     patch:
       summary: Update a specific impact type.
@@ -348,13 +371,7 @@ paths:
       operationId: getComponents
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Component'
+          $ref: '#/components/responses/Response'
 
     post:
       summary: Create a new component.
@@ -418,13 +435,7 @@ paths:
         description: End of time frame to query for (RFC3339).
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Incident'
+          $ref: '#/components/responses/Response'
 
     post:
       summary: Create a new incident.
@@ -443,11 +454,7 @@ paths:
       - $ref: '#/components/parameters/IncidentIdPathParameter'
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Incident'
+          $ref: '#/components/responses/Response'
 
     patch:
       summary: Update an incident.
@@ -477,13 +484,7 @@ paths:
         - $ref: '#/components/parameters/IncidentIdPathParameter'
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/IncidentUpdate'
+          $ref: '#/components/responses/Response'
 
     post:
       summary: Create a new update to a specific incident.
@@ -505,11 +506,7 @@ paths:
         - $ref: '#/components/parameters/IncidentUpdateIdPathParameter'
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/IncidentUpdate'
+          $ref: '#/components/responses/Response'
 
     patch:
       summary: Update a specific update from a specific incident.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9,17 +9,37 @@ components:
       description: Identification for objects. UUID preferred.
       type: string
 
-    IdList:
-      description: List of IDs for referencing other objects.
-      type: array
-      items:
-        $ref: '#/components/schemas/Id'
-      readOnly: true
+    IdField:
+      description: Id field for responses.
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/Id'
+      required:
+        - id
 
     Incremental:
       description: |
         Positive and incrementing number for ordering and identfication of e.g. sub resources.
       type: integer
+
+    Generation:
+      description: Incremental as generation field for responses.
+      type: object
+      properties:
+        generation:
+          $ref: '#/components/schemas/Incremental'
+      required:
+        - generation
+
+    Order:
+      description: Incremental as order field for responses.
+      type: object
+      properties:
+        order:
+          $ref: '#/components/schemas/Incremental'
+      required:
+        - order
 
     IncrementalList:
       description: List of Incrementals for referencing subresources.
@@ -46,18 +66,10 @@ components:
     ImpactType:
       type: object
       properties:
-        id:
-          $ref: '#/components/schemas/Id'
         displayName:
           $ref: '#/components/schemas/DisplayName'
         description:
           $ref: '#/components/schemas/Description'
-
-    ImpactTypeList:
-      type: array
-      items:
-        $ref: '#/components/schemas/ImpactType'
-      readOnly: true
 
     Impact:
       description: An impact connects a component and an incident with an impact type.
@@ -95,23 +107,14 @@ components:
     PhaseReference:
       description: To reference a phase, its generation and order is needed.
       type: object
-      properties:
-        displayName:
-          $ref: '#/components/schemas/DisplayName'
-        order:
-          $ref: '#/components/schemas/Incremental'
-        generation:
-          $ref: '#/components/schemas/Incremental'
-      required:
-        - order
-        - generation
+      allOf:
+        - $ref: '#/components/schemas/Order'
+        - $ref: '#/components/schemas/Generation'
 
     PhaseList:
       description: Phase resources are always handled as a list.
       type: object
       properties:
-        generation:
-          $ref: '#/components/schemas/Incremental'
         phases:
           type: array
           items:
@@ -126,8 +129,6 @@ components:
         Updates happen in a given order.
       type: object
       properties:
-        order:
-          $ref: '#/components/schemas/Incremental'
         displayName:
           $ref: '#/components/schemas/DisplayName'
         description:
@@ -136,12 +137,6 @@ components:
           $ref: '#/components/schemas/Date'
       required:
         - order
-
-    IncidentUpdateList:
-      type: array
-      items:
-        $ref: '#/components/schemas/IncidentUpdate'
-      readOnly: true
 
     Labels:
       description: Labels are free text key value pairs for components.
@@ -152,8 +147,6 @@ components:
     Component:
       type: object
       properties:
-        id:
-          $ref: '#/components/schemas/Id'
         displayName:
           $ref: '#/components/schemas/DisplayName'
         labels:
@@ -161,17 +154,9 @@ components:
         activelyAffectedBy:
           $ref: '#/components/schemas/ImpactIncidentList'
 
-    ComponentList:
-      type: array
-      items:
-        $ref: '#/components/schemas/Component'
-      readOnly: true
-
     Incident:
       type: object
       properties:
-        id:
-          $ref: '#/components/schemas/Id'
         displayName:
           $ref: '#/components/schemas/DisplayName'
         description:
@@ -188,12 +173,6 @@ components:
           $ref: '#/components/schemas/PhaseReference'
       required:
         - id
-
-    IncidentList:
-      type: array
-      items:
-        $ref: '#/components/schemas/Incident'
-      readOnly: true
 
   # parameter
   parameters:
@@ -280,31 +259,21 @@ components:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              id:
-                $ref: '#/components/schemas/Id'
+            $ref: '#/components/schemas/IdField'
 
     GenerationResponse:
       description: A request returns a generation.
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              generation:
-                $ref: '#/components/schemas/Incremental'
+            $ref: '#/components/schemas/Generation'
 
     OrderResponse:
       description: A request returns an order.
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              order:
-                $ref: '#/components/schemas/Incremental'
-
+            $ref: '#/components/schemas/Order'
 
     PhaseListResponse:
       description: A request returns a phase list.
@@ -314,7 +283,9 @@ components:
             type: object
             properties:
               data:
-                $ref: '#/components/schemas/PhaseList'
+                allOf:
+                  - $ref: '#/components/schemas/Generation'
+                  - $ref: '#/components/schemas/PhaseList'
 
     ImpactTypeResponse:
       description: A request returns an impact type.
@@ -324,7 +295,9 @@ components:
             type: object
             properties:
               data:
-                $ref: '#/components/schemas/ImpactType'
+                allOf:
+                  - $ref: '#/components/schemas/IdField'
+                  - $ref: '#/components/schemas/ImpactType'
 
     ImpactTypeListResponse:
       description: A request returns a list of impact types.
@@ -334,7 +307,12 @@ components:
             type: object
             properties:
               data:
-                $ref: '#/components/schemas/ImpactTypeList'
+                type: array
+                items:
+                  type: object
+                  allOf:
+                    - $ref: '#/components/schemas/IdField'
+                    - $ref: '#/components/schemas/ImpactType'
 
     ComponentResponse:
       description: A request returns a component.
@@ -344,7 +322,9 @@ components:
             type: object
             properties:
               data:
-                $ref: '#/components/schemas/Component'
+                allOf:
+                  - $ref: '#/components/schemas/IdField'
+                  - $ref: '#/components/schemas/Component'
 
     ComponentListResponse:
       description: A request returns a list of components.
@@ -354,7 +334,12 @@ components:
             type: object
             properties:
               data:
-                $ref: '#/components/schemas/ComponentList'
+                type: array
+                items:
+                  type: object
+                  allOf:
+                    - $ref: '#/components/schemas/IdField'
+                    - $ref: '#/components/schemas/Component'
 
     IncidentResponse:
       description: A request returns an incident.
@@ -364,7 +349,9 @@ components:
             type: object
             properties:
               data:
-                $ref: '#/components/schemas/Incident'
+                allOf:
+                  - $ref: '#/components/schemas/IdField'
+                  - $ref: '#/components/schemas/Incident'
 
     IncidentListResponse:
       description: A request returns a list of incidents.
@@ -374,7 +361,12 @@ components:
             type: object
             properties:
               data:
-                $ref: '#/components/schemas/IncidentList'
+                type: array
+                items:
+                  type: object
+                  allOf:
+                    - $ref: '#/components/schemas/IdField'
+                    - $ref: '#/components/schemas/Incident'
 
     IncidentUpdateResponse:
       description: A request returns an incident update.
@@ -384,7 +376,9 @@ components:
             type: object
             properties:
               data:
-                $ref: '#/components/schemas/IncidentUpdate'
+                allOf:
+                  - $ref: '#/components/schemas/Order'
+                  - $ref: '#/components/schemas/IncidentUpdate'
 
     IncidentUpdateListResponse:
       description: A request returns a list of incident updates.
@@ -394,7 +388,12 @@ components:
             type: object
             properties:
               data:
-                $ref: '#/components/schemas/IncidentUpdateList'
+                type: array
+                items:
+                  type: object
+                  allOf:
+                    - $ref: '#/components/schemas/Order'
+                    - $ref: '#/components/schemas/IncidentUpdate'
 
 paths:
   /phases:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -25,12 +25,9 @@ components:
         type: string
     Component:
       type: object
-      required:
-        - id
       properties:
         id:
-          type: string
-          readOnly: true
+          $ref: '#/components/schemas/Id'
         displayName:
           type: string
         labels:
@@ -41,12 +38,9 @@ components:
             $ref: '#/components/schemas/Id'
     Incident:
       type: object
-      required:
-        - id
       properties:
         id:
-          type: string
-          readOnly: true
+          $ref: '#/components/schemas/Id'
         title:
           type: string
         description:
@@ -183,7 +177,7 @@ paths:
         name: componentId
         required: true
         schema:
-          type: string
+          $ref: '#/components/schemas/Id'
       responses:
         '200':
           description: OK
@@ -199,7 +193,7 @@ paths:
           in: path
           required: true
           schema:
-            type: string
+            $ref: '#/components/schemas/Id'
       responses:
         '200':
           $ref: "#/components/responses/SuccessResponse"
@@ -211,7 +205,7 @@ paths:
         name: componentId
         required: true
         schema:
-          type: string
+          $ref: '#/components/schemas/Id'
       requestBody:
         $ref: '#/components/requestBodies/ComponentRequest'
       responses:
@@ -263,7 +257,7 @@ paths:
         name: incidentId
         required: true
         schema:
-          type: string
+          $ref: '#/components/schemas/Id'
       responses:
         '200':
           description: OK
@@ -279,7 +273,7 @@ paths:
           in: path
           required: true
           schema:
-            type: string
+            $ref: '#/components/schemas/Id'
       responses:
         '200':
           $ref: "#/components/responses/SuccessResponse"
@@ -291,7 +285,7 @@ paths:
           in: path
           required: true
           schema:
-            type: string
+            $ref: '#/components/schemas/Id'
       requestBody:
         $ref: '#/components/requestBodies/IncidentRequest'
       responses:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -64,7 +64,7 @@ components:
       type: object
       properties:
         type:
-          $ref: '#/components/schemas/ImpactType'
+          $ref: '#/components/schemas/Id'
         reference:
           $ref: '#/components/schemas/Id'
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -25,9 +25,12 @@ components:
         type: string
     Component:
       type: object
+      required:
+        - id
       properties:
         id:
           type: string
+          readOnly: true
         displayName:
           type: string
         labels:
@@ -38,9 +41,12 @@ components:
             $ref: '#/components/schemas/Id'
     Incident:
       type: object
+      required:
+        - id
       properties:
         id:
           type: string
+          readOnly: true
         title:
           type: string
         description:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -133,6 +133,23 @@ paths:
             application/json:
               schema:
                 type: string
+  /impacttypes/{impactType}:
+    delete:
+      summary: Delete a impact type
+      operationId: deleteImpactType
+      parameters:
+        - name: impactType
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/IncidentImpactType'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: boolean
   /components:
     get:
       responses:
@@ -176,6 +193,22 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Component'
+    delete:
+      summary: Delete a component
+      operationId: deleteComponent
+      parameters:
+        - name: componentId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: boolean
   /incidents:
     get:
       summary: Get list of incidents
@@ -237,3 +270,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Incident'
+    delete:
+      summary: Delete a incident
+      operationId: deleteIncident
+      parameters:
+        - name: incidentId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: boolean

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -198,27 +198,6 @@ components:
         $ref: '#/components/schemas/Incident'
       readOnly: true
 
-    ResponseData:
-      description: |
-        Wraps the retuned data in an object.
-        See: https://github.com/SovereignCloudStack/status-page-openapi/issues/6
-      type: object
-      properties:
-        content:
-          oneOf:
-            - $ref: '#/components/schemas/Success'
-            - $ref: '#/components/schemas/Id'
-            - $ref: '#/components/schemas/Incremental'
-            - $ref: '#/components/schemas/PhaseList'
-            - $ref: '#/components/schemas/ImpactType'
-            - $ref: '#/components/schemas/ImpactTypeList'
-            - $ref: '#/components/schemas/Component'
-            - $ref: '#/components/schemas/ComponentList'
-            - $ref: '#/components/schemas/Incident'
-            - $ref: '#/components/schemas/IncidentList'
-            - $ref: '#/components/schemas/IncidentUpdate'
-            - $ref: '#/components/schemas/IncidentUpdateList'
-
   # requests
   requestBodies:
     ComponentRequest:
@@ -251,12 +230,125 @@ components:
 
   # responses
   responses:
-    Response:
-      description: General response for successful operations.
+    SuccessResponse:
+      description: A request has successfully run.
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ResponseData'
+            type: object
+            properties:
+              data:
+                $ref: '#/components/schemas/Success'
+
+    IdResponse:
+      description: A request returns an ID.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: '#/components/schemas/Id'
+
+    IncrementalResponse:
+      description: A request returns an Incremental.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: '#/components/schemas/Incremental'
+
+    PhaseListResponse:
+      description: A request returns a phase list.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: '#/components/schemas/PhaseList'
+
+    ImpactTypeResponse:
+      description: A request returns an impact type.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: '#/components/schemas/ImpactType'
+
+    ImpactTypeListResponse:
+      description: A request returns a list of impact types.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: '#/components/schemas/ImpactTypeList'
+
+    ComponentResponse:
+      description: A request returns a component.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: '#/components/schemas/Component'
+
+    ComponentListResponse:
+      description: A request returns a list of components.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: '#/components/schemas/ComponentList'
+
+    IncidentResponse:
+      description: A request returns an incident.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: '#/components/schemas/Incident'
+
+    IncidentListResponse:
+      description: A request returns a list of incidents.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: '#/components/schemas/IncidentList'
+
+    IncidentUpdateResponse:
+      description: A request returns an incident update.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: '#/components/schemas/IncidentUpdate'
+
+    IncidentUpdateListResponse:
+      description: A request returns a list of incident updates.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: '#/components/schemas/IncidentUpdateList'
 
   # parameter
   parameters:
@@ -304,7 +396,7 @@ paths:
             $ref: '#/components/schemas/Incremental'
       responses:
         '200':
-          $ref: '#/components/responses/Response'
+          $ref: '#/components/responses/PhaseListResponse'
 
     post:
       summary: Create a new generation of the phase list.
@@ -316,7 +408,7 @@ paths:
               $ref: '#/components/schemas/PhaseList'
       responses:
         '201':
-          $ref: '#/components/responses/Response'
+          $ref: '#/components/responses/IncrementalResponse'
 
   /impacttypes:
     get:
@@ -324,7 +416,7 @@ paths:
       operationId: getImpactTypes
       responses:
         '200':
-          $ref: '#/components/responses/Response'
+          $ref: '#/components/responses/ImpactTypeListResponse'
 
     post:
       summary: Create a new impact type.
@@ -333,7 +425,7 @@ paths:
         $ref: '#/components/requestBodies/ImpactTypeRequest'
       responses:
         '201':
-          $ref: '#/components/responses/Response'
+          $ref: '#/components/responses/IdResponse'
 
   /impacttypes/{impactTypeId}:
     get:
@@ -343,7 +435,7 @@ paths:
         - $ref: '#/components/parameters/ImpactTypeIdPathParameter'
       responses:
         '200':
-          $ref: '#/components/responses/Response'
+          $ref: '#/components/responses/ImpactTypeResponse'
 
     patch:
       summary: Update a specific impact type.
@@ -354,7 +446,7 @@ paths:
         $ref: '#/components/requestBodies/ImpactTypeRequest'
       responses:
         '200':
-          $ref: '#/components/responses/Response'
+          $ref: '#/components/responses/SuccessResponse'
 
     delete:
       summary: Delete an impact type.
@@ -363,7 +455,7 @@ paths:
         - $ref: '#/components/parameters/ImpactTypeIdPathParameter'
       responses:
         '200':
-          $ref: "#/components/responses/Response"
+          $ref: "#/components/responses/SuccessResponse"
 
   /components:
     get:
@@ -371,7 +463,7 @@ paths:
       operationId: getComponents
       responses:
         '200':
-          $ref: '#/components/responses/Response'
+          $ref: '#/components/responses/ComponentListResponse'
 
     post:
       summary: Create a new component.
@@ -380,7 +472,7 @@ paths:
         $ref: '#/components/requestBodies/ComponentRequest'
       responses:
         '201':
-          $ref: '#/components/responses/Response'
+          $ref: '#/components/responses/IdResponse'
 
   /components/{componentId}:
     get:
@@ -390,7 +482,7 @@ paths:
       - $ref: '#/components/parameters/ComponentIdPathParameter'
       responses:
         '200':
-          $ref: '#/components/responses/Response'
+          $ref: '#/components/responses/ComponentResponse'
 
     patch:
       summary: Update a component.
@@ -401,7 +493,7 @@ paths:
         $ref: '#/components/requestBodies/ComponentRequest'
       responses:
         '200':
-          $ref: "#/components/responses/Response"
+          $ref: "#/components/responses/SuccessResponse"
 
     delete:
       summary: Delete a component.
@@ -410,7 +502,7 @@ paths:
         - $ref: '#/components/parameters/ComponentIdPathParameter'
       responses:
         '200':
-          $ref: "#/components/responses/Response"
+          $ref: "#/components/responses/SuccessResponse"
 
   /incidents:
     get:
@@ -435,7 +527,7 @@ paths:
         description: End of time frame to query for (RFC3339).
       responses:
         '200':
-          $ref: '#/components/responses/Response'
+          $ref: '#/components/responses/IncidentListResponse'
 
     post:
       summary: Create a new incident.
@@ -444,7 +536,7 @@ paths:
         $ref: '#/components/requestBodies/IncidentRequest'
       responses:
         '201':
-          $ref: '#/components/responses/Response'
+          $ref: '#/components/responses/IdResponse'
 
   /incidents/{incidentId}:
     get:
@@ -454,7 +546,7 @@ paths:
       - $ref: '#/components/parameters/IncidentIdPathParameter'
       responses:
         '200':
-          $ref: '#/components/responses/Response'
+          $ref: '#/components/responses/IncidentResponse'
 
     patch:
       summary: Update an incident.
@@ -465,7 +557,7 @@ paths:
         $ref: '#/components/requestBodies/IncidentRequest'
       responses:
         '200':
-          $ref: "#/components/responses/Response"
+          $ref: "#/components/responses/SuccessResponse"
 
     delete:
       summary: Delete an incident.
@@ -474,7 +566,7 @@ paths:
         - $ref: '#/components/parameters/IncidentIdPathParameter'
       responses:
         '200':
-          $ref: "#/components/responses/Response"
+          $ref: "#/components/responses/SuccessResponse"
 
   /incidents/{incidentId}/updates:
     get:
@@ -484,7 +576,7 @@ paths:
         - $ref: '#/components/parameters/IncidentIdPathParameter'
       responses:
         '200':
-          $ref: '#/components/responses/Response'
+          $ref: '#/components/responses/IncidentUpdateListResponse'
 
     post:
       summary: Create a new update to a specific incident.
@@ -495,7 +587,7 @@ paths:
         $ref: '#/components/requestBodies/IncidentUpdateRequest'
       responses:
         '201':
-          $ref: '#/components/responses/Response'
+          $ref: '#/components/responses/IncrementalResponse'
 
   /incidents/{incidentId}/updates/{updateId}:
     get:
@@ -506,7 +598,7 @@ paths:
         - $ref: '#/components/parameters/IncidentUpdateIdPathParameter'
       responses:
         '200':
-          $ref: '#/components/responses/Response'
+          $ref: '#/components/responses/IncidentUpdateResponse'
 
     patch:
       summary: Update a specific update from a specific incident.
@@ -518,7 +610,7 @@ paths:
         $ref: '#/components/requestBodies/IncidentUpdateRequest'
       responses:
         '200':
-          $ref: "#/components/responses/Response"
+          $ref: "#/components/responses/SuccessResponse"
 
     delete:
       summary: Delete a specific update from a specific incident
@@ -528,4 +620,4 @@ paths:
         - $ref: '#/components/parameters/IncidentUpdateIdPathParameter'
       responses:
         '200':
-          $ref: "#/components/responses/Response"
+          $ref: "#/components/responses/SuccessResponse"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,151 +4,285 @@ info:
   version: '1.0'
 components:
   schemas:
+    # common values
     Id:
+      description: Identfication for objects. UUID prefered.
       type: string
       readOnly: true
+
     IdList:
+      description: List of IDs for referencing other objects.
       type: array
       items:
         $ref: '#/components/schemas/Id'
-    IncidentImpactType:
+
+    Incremental:
+      description: |
+        Positive and incrementing number for ordering and identfication of e.g. sub resources.
+      type: integer
+      readOnly: true
+
+    DisplayName:
+      description: Short and describing name.
       type: string
-    IncidentPhase:
+
+    Description:
+      description: A longer text for detailed informations.
       type: string
-    IncidentUpdate:
+
+    Date:
+      description: Point in time. Nullable for open ends.
+      type: string
+      format: date-time
+      nullable: true
+
+    # API objects
+    ImpactType:
       type: object
       properties:
         id:
           $ref: '#/components/schemas/Id'
-        text:
-          type: string
-        createdAt:
-          type: string
-          format: date-time
+        displayName:
+          $ref: '#/components/schemas/DisplayName'
+        description:
+          $ref: '#/components/schemas/Description'
       required:
         - id
-        - text
+
+    Impact:
+      description: An impact connects a component and an incident with an impact type.
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/ImpactType'
+        reference:
+          $ref: '#/components/schemas/Id'
+
+    ImpactList:
+      description: |
+        A list of impacts for a component or incident.
+        In case of an incident the IDs refer to a component and vice versa.
+      type: array
+      items:
+        $ref: '#/components/schemas/Impact'
+
+    Phase:
+      description: |
+        A single phase is just its name.
+        It can be referenced by its generation and order.
+        See: #/components/schemas/DisplayName
+      type: string
+
+    PhaseReference:
+      description: To reference a phase, its generation and order is needed.
+      type: object
+      properties:
+        displayName:
+          $ref: '#/components/schemas/DisplayName'
+        order:
+          $ref: '#/components/schemas/Incremental'
+        generation:
+          $ref: '#/components/schemas/Incremental'
+      required:
+        - order
+        - generation
+
+    PhaseList:
+      description: Phase resources are always handled as a list.
+      type: object
+      properties:
+        generation:
+          $ref: '#/components/schemas/Incremental'
+        phases:
+          type: array
+          items:
+            $ref: '#/components/schemas/Phase'
+      required:
+        - generation
+        - phases
+
+    IncidentUpdate:
+      description: |
+        An update is a sub resource to an incident.
+        It's identified by the incident ID and its own order.
+        Updates happen in a given order.
+      type: object
+      properties:
+        order:
+          $ref: '#/components/schemas/Incremental'
+        displayName:
+          $ref: '#/components/schemas/DisplayName'
+        description:
+          $ref: '#/components/schemas/Description'
+        createdAt:
+          $ref: '#/components/schemas/Date'
+      required:
+        - order
         - createdAt
+
     Labels:
+      description: Labels are free text key value pairs for components.
       type: object
       additionalProperties:
         type: string
+
     Component:
       type: object
       properties:
         id:
           $ref: '#/components/schemas/Id'
         displayName:
-          type: string
+          $ref: '#/components/schemas/DisplayName'
         labels:
           $ref: '#/components/schemas/Labels'
         affectedBy:
-          $ref: '#/components/schemas/IdList'
+          $ref: '#/components/schemas/ImpactList'
       required:
         - id
+
     Incident:
       type: object
       properties:
         id:
           $ref: '#/components/schemas/Id'
-        title:
-          type: string
+        displayName:
+          $ref: '#/components/schemas/DisplayName'
         description:
-          type: string
+          $ref: '#/components/schemas/Description'
         updates:
-          $ref: '#/components/schemas/IdList'
+          $ref: '#/components/schemas/Incremental'
         affects:
-          $ref: '#/components/schemas/IdList'
+          $ref: '#/components/schemas/ImpactList'
         beganAt:
-          type: string
-          format: date-time
+          $ref: '#/components/schemas/Date'
         endedAt:
-          type: string
-          format: date-time
-          nullable: true
-        impactType:
-          $ref: '#/components/schemas/IncidentImpactType'
+          $ref: '#/components/schemas/Date'
         phase:
-          $ref: '#/components/schemas/IncidentPhase'
+          $ref: '#/components/schemas/PhaseReference'
       required:
         - id
+
+  # requests
   requestBodies:
     ComponentRequest:
-      description: Send a component
+      description: Send a component.
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/Component'
+
     IncidentRequest:
-      description: Send an incident
+      description: Send an incident.
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/Incident'
+
     IncidentUpdateRequest:
-      description: Send an incident update
+      description: Send an incident update.
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/IncidentUpdate'
+
+    ImpactTypeRequest:
+      description: Send an impact type.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ImpactType'
+
+  # responses
   responses:
     SuccessResponse:
-      description: A request has successfully run
+      description: A request has successfully run.
       content:
         application/json:
           schema:
             type: boolean
+
     IdResponse:
-      description: A request returns an ID
+      description: A request returns an ID.
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/Id'
+
+    IncrementalResponse:
+      description: A request returns an Incremental.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Incremental'
+
+  # parameter
   parameters:
     ComponentIdPathParameter:
+      description: Component ID is required in path.
       name: componentId
       in: path
       required: true
       schema:
         $ref: '#/components/schemas/Id'
+
     IncidentIdPathParameter:
+      description: Incident ID is required in path.
       name: incidentId
       in: path
       required: true
       schema:
         $ref: '#/components/schemas/Id'
+
     IncidentUpdateIdPathParameter:
+      description: Incident update id (inremental) is required in path.
       name: updateId
       in: path
       required: true
       schema:
+        $ref: '#/components/schemas/Incremental'
+
+    ImpactTypeIdPathParameter:
+      description: Impact type ID is required in path.
+      name: impactTypeId
+      in: path
+      required: true
+      schema:
         $ref: '#/components/schemas/Id'
+
 paths:
   /phases:
     get:
+      summary: Get the current generation list of phases.
+      operationId: getPhaseList
+      parameters:
+        - name: generation
+          in: query
+          schema:
+            $ref: '#/components/schemas/Incremental'
       responses:
         '200':
           description: OK
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/IncidentPhase'
-    put:
-      summary: Create a new list of phases.
+                $ref: '#/components/schemas/PhaseList'
+
+    post:
+      summary: Create a new generation of the phase list.
+      operationId: createPhaseList
       requestBody:
         content:
           application/json:
             schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/IncidentPhase'
+              $ref: '#/components/schemas/PhaseList'
       responses:
-        '200':
-          $ref: "#/components/responses/SuccessResponse"
+        '201':
+          $ref: '#/components/responses/IncrementalResponse'
+
   /impacttypes:
     get:
+      summary: Get a list of impact types.
+      operationId: getImpactTypes
       responses:
         '200':
           description: OK
@@ -157,33 +291,55 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/IncidentImpactType'
+                  $ref: '#/components/schemas/ImpactType'
+
     post:
-      summary: Create a new impact type
+      summary: Create a new impact type.
       operationId: createImpactType
       requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/IncidentImpactType'
+        $ref: '#/components/requestBodies/ImpactTypeRequest'
       responses:
         '201':
           $ref: '#/components/responses/IdResponse'
-  /impacttypes/{impactType}:
+
+  /impacttypes/{impactTypeId}:
+    get:
+      summary: Get a specific impact type by id.
+      operationId: getImpactType
+      parameters:
+        - $ref: '#/components/parameters/ImpactTypeIdPathParameter'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImpactType'
+
+    patch:
+      summary: Update a specific impact type.
+      operationId: updateImpactType
+      parameters:
+        - $ref: '#/components/parameters/ImpactTypeIdPathParameter'
+      requestBody:
+        $ref: '#/components/requestBodies/ImpactTypeRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessResponse'
+
     delete:
-      summary: Delete an impact type
+      summary: Delete an impact type.
       operationId: deleteImpactType
       parameters:
-        - name: impactType
-          in: path
-          required: true
-          schema:
-            $ref: '#/components/schemas/IncidentImpactType'
+        - $ref: '#/components/parameters/ImpactTypeIdPathParameter'
       responses:
         '200':
           $ref: "#/components/responses/SuccessResponse"
+
   /components:
     get:
+      summary: Get a list of components.
+      operationId: getComponents
       responses:
         '200':
           description: OK
@@ -193,37 +349,28 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Component'
+
     post:
-      summary: Create a new component
+      summary: Create a new component.
       operationId: createComponent
       requestBody:
         $ref: '#/components/requestBodies/ComponentRequest'
       responses:
         '201':
           $ref: '#/components/responses/IdResponse'
+
   /components/{componentId}:
     get:
-      summary: Get specific component by id
+      summary: Get a specific component by id.
       operationId: getComponent
       parameters:
       - $ref: '#/components/parameters/ComponentIdPathParameter'
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Component'
-    delete:
-      summary: Delete a component
-      operationId: deleteComponent
-      parameters:
-        - $ref: '#/components/parameters/ComponentIdPathParameter'
-      responses:
-        '200':
-          $ref: "#/components/responses/SuccessResponse"
+          $ref: '#/components/responses/IdResponse'
+
     patch:
-      summary: Fully or partially change a component
+      summary: Update a component.
       operationId: updateComponent
       parameters:
       - $ref: '#/components/parameters/ComponentIdPathParameter'
@@ -232,9 +379,20 @@ paths:
       responses:
         '200':
           $ref: "#/components/responses/SuccessResponse"
+
+    delete:
+      summary: Delete a component.
+      operationId: deleteComponent
+      parameters:
+        - $ref: '#/components/parameters/ComponentIdPathParameter'
+      responses:
+        '200':
+          $ref: "#/components/responses/SuccessResponse"
+
   /incidents:
     get:
-      summary: Get list of incidents
+      summary: Get a list of incidents between two points in time.
+      operationId: getIncidents
       parameters:
       - in: query
         name: start
@@ -243,7 +401,7 @@ paths:
           format: date-time
           default: '2022-01-01T10:10:10.010Z'
         required: true
-        description: Start of time frame to query for (RFC3339)
+        description: Start of time frame to query for (RFC3339).
       - in: query
         name: end
         schema:
@@ -251,7 +409,7 @@ paths:
           format: date-time
           default: '2024-01-01T10:10:10.010Z'
         required: true
-        description: End of time frame to query for (RFC3339)
+        description: End of time frame to query for (RFC3339).
       responses:
         '200':
           description: OK
@@ -261,17 +419,19 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Incident'
+
     post:
-      summary: Create a new incident
+      summary: Create a new incident.
       operationId: createIncident
       requestBody:
         $ref: '#/components/requestBodies/IncidentRequest'
       responses:
         '201':
           $ref: '#/components/responses/IdResponse'
+
   /incidents/{incidentId}:
     get:
-      summary: Get specific incident by id
+      summary: Get a specific incident by id.
       operationId: getIncident
       parameters:
       - $ref: '#/components/parameters/IncidentIdPathParameter'
@@ -282,16 +442,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Incident'
-    delete:
-      summary: Delete a incident
-      operationId: deleteIncident
-      parameters:
-        - $ref: '#/components/parameters/IncidentIdPathParameter'
-      responses:
-        '200':
-          $ref: "#/components/responses/SuccessResponse"
+
     patch:
-      summary: Fully or partially change a incident
+      summary: Update an incident.
       operationId: updateIncident
       parameters:
         - $ref: '#/components/parameters/IncidentIdPathParameter'
@@ -300,9 +453,19 @@ paths:
       responses:
         '200':
           $ref: "#/components/responses/SuccessResponse"
+
+    delete:
+      summary: Delete an incident.
+      operationId: deleteIncident
+      parameters:
+        - $ref: '#/components/parameters/IncidentIdPathParameter'
+      responses:
+        '200':
+          $ref: "#/components/responses/SuccessResponse"
+
   /incidents/{incidentId}/updates:
     get:
-      summary: Get updates of a specific incident
+      summary: Get a list of updates from a specific incident.
       operationId: getIncidentUpdates
       parameters:
         - $ref: '#/components/parameters/IncidentIdPathParameter'
@@ -315,8 +478,9 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/IncidentUpdate'
+
     post:
-      summary: Create a new update to a specific incident
+      summary: Create a new update to a specific incident.
       operationId: createIncidentUpdate
       parameters:
         - $ref: '#/components/parameters/IncidentIdPathParameter'
@@ -325,9 +489,10 @@ paths:
       responses:
         '201':
           $ref: '#/components/responses/IdResponse'
+
   /incidents/{incidentId}/updates/{updateId}:
     get:
-      summary: Get a specific update from a specific incident
+      summary: Get a specific update from a specific incident.
       operationId: getIncidentUpdate
       parameters:
         - $ref: '#/components/parameters/IncidentIdPathParameter'
@@ -339,23 +504,25 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/IncidentUpdate'
-    delete:
-      summary: Delete a specific update from a specific incident
-      operationId: deleteIncidentUpdate
-      parameters:
-        - $ref: '#/components/parameters/IncidentIdPathParameter'
-        - $ref: '#/components/parameters/IncidentUpdateIdPathParameter'
-      responses:
-        '200':
-          $ref: "#/components/responses/SuccessResponse"
+
     patch:
-      summary: Update a specific update from a specific incident
+      summary: Update a specific update from a specific incident.
       operationId: updateIncidentUpdate
       parameters:
         - $ref: '#/components/parameters/IncidentIdPathParameter'
         - $ref: '#/components/parameters/IncidentUpdateIdPathParameter'
       requestBody:
         $ref: '#/components/requestBodies/IncidentUpdateRequest'
+      responses:
+        '200':
+          $ref: "#/components/responses/SuccessResponse"
+
+    delete:
+      summary: Delete a specific update from a specific incident
+      operationId: deleteIncidentUpdate
+      parameters:
+        - $ref: '#/components/parameters/IncidentIdPathParameter'
+        - $ref: '#/components/parameters/IncidentUpdateIdPathParameter'
       responses:
         '200':
           $ref: "#/components/responses/SuccessResponse"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8,7 +8,6 @@ components:
     Id:
       description: Identification for objects. UUID preferred.
       type: string
-      readOnly: true
 
     IdList:
       description: List of IDs for referencing other objects.
@@ -21,7 +20,6 @@ components:
       description: |
         Positive and incrementing number for ordering and identfication of e.g. sub resources.
       type: integer
-      readOnly: true
 
     IncrementalList:
       description: List of Incrementals for referencing subresources.
@@ -54,8 +52,6 @@ components:
           $ref: '#/components/schemas/DisplayName'
         description:
           $ref: '#/components/schemas/Description'
-      required:
-        - id
 
     ImpactTypeList:
       type: array
@@ -72,13 +68,22 @@ components:
         reference:
           $ref: '#/components/schemas/Id'
 
-    ImpactList:
+    ImpactComponentList:
       description: |
-        A list of impacts for a component or incident.
-        In case of an incident the IDs refer to a component and vice versa.
+        A list of impacts for an incident.
+        Impacts reference components.
       type: array
       items:
         $ref: '#/components/schemas/Impact'
+
+    ImpactIncidentList:
+      description: |
+        A list of impacts for an component.
+        Impacts reference incidents.
+      type: array
+      items:
+        $ref: '#/components/schemas/Impact'
+      readOnly: true
 
     Phase:
       description: |
@@ -112,7 +117,6 @@ components:
           items:
             $ref: '#/components/schemas/Phase'
       required:
-        - generation
         - phases
 
     IncidentUpdate:
@@ -132,7 +136,6 @@ components:
           $ref: '#/components/schemas/Date'
       required:
         - order
-        - createdAt
 
     IncidentUpdateList:
       type: array
@@ -155,10 +158,8 @@ components:
           $ref: '#/components/schemas/DisplayName'
         labels:
           $ref: '#/components/schemas/Labels'
-        affectedBy:
-          $ref: '#/components/schemas/ImpactList'
-      required:
-        - id
+        activelyAffectedBy:
+          $ref: '#/components/schemas/ImpactIncidentList'
 
     ComponentList:
       type: array
@@ -178,7 +179,7 @@ components:
         updates:
           $ref: '#/components/schemas/IncrementalList'
         affects:
-          $ref: '#/components/schemas/ImpactList'
+          $ref: '#/components/schemas/ImpactComponentList'
         beganAt:
           $ref: '#/components/schemas/Date'
         endedAt:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -44,10 +44,6 @@ components:
       format: date-time
       nullable: true
 
-    Success:
-      description: An operation was successful.
-      type: boolean
-
     # API objects
     ImpactType:
       type: object
@@ -278,16 +274,6 @@ components:
 
   # responses
   responses:
-    SuccessResponse:
-      description: A request has successfully run.
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              data:
-                $ref: '#/components/schemas/Success'
-
     IdResponse:
       description: A request returns an ID.
       content:
@@ -453,8 +439,8 @@ paths:
       requestBody:
         $ref: '#/components/requestBodies/ImpactTypeRequest'
       responses:
-        '200':
-          $ref: '#/components/responses/SuccessResponse'
+        '204':
+          description: Successful. No Content
 
     delete:
       summary: Delete an impact type.
@@ -462,8 +448,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/ImpactTypeIdPathParameter'
       responses:
-        '200':
-          $ref: "#/components/responses/SuccessResponse"
+        '204':
+          description: Successful. No Content
 
   /components:
     get:
@@ -500,8 +486,8 @@ paths:
       requestBody:
         $ref: '#/components/requestBodies/ComponentRequest'
       responses:
-        '200':
-          $ref: "#/components/responses/SuccessResponse"
+        '204':
+          description: Successful. No Content
 
     delete:
       summary: Delete a component.
@@ -509,8 +495,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/ComponentIdPathParameter'
       responses:
-        '200':
-          $ref: "#/components/responses/SuccessResponse"
+        '204':
+          description: Successful. No Content
 
   /incidents:
     get:
@@ -564,8 +550,8 @@ paths:
       requestBody:
         $ref: '#/components/requestBodies/IncidentRequest'
       responses:
-        '200':
-          $ref: "#/components/responses/SuccessResponse"
+        '204':
+          description: Successful. No Content
 
     delete:
       summary: Delete an incident.
@@ -573,8 +559,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/IncidentIdPathParameter'
       responses:
-        '200':
-          $ref: "#/components/responses/SuccessResponse"
+        '204':
+          description: Successful. No Content
 
   /incidents/{incidentId}/updates:
     get:
@@ -617,8 +603,8 @@ paths:
       requestBody:
         $ref: '#/components/requestBodies/IncidentUpdateRequest'
       responses:
-        '200':
-          $ref: "#/components/responses/SuccessResponse"
+        '204':
+          description: Successful. No Content
 
     delete:
       summary: Delete a specific update from a specific incident
@@ -627,5 +613,5 @@ paths:
         - $ref: '#/components/parameters/IncidentIdPathParameter'
         - $ref: '#/components/parameters/IncidentUpdateIdPathParameter'
       responses:
-        '200':
-          $ref: "#/components/responses/SuccessResponse"
+        '204':
+          description: Successful. No Content

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -219,9 +219,9 @@ components:
       schema:
         $ref: '#/components/schemas/Id'
 
-    IncidentUpdateIdPathParameter:
-      description: Incident update id (inremental) is required in path.
-      name: updateId
+    IncidentUpdateOrderPathParameter:
+      description: Incident update order (inremental) is required in path.
+      name: updateOrder
       in: path
       required: true
       schema:
@@ -281,18 +281,29 @@ components:
           schema:
             type: object
             properties:
-              data:
+              id:
                 $ref: '#/components/schemas/Id'
 
-    IncrementalResponse:
-      description: A request returns an Incremental.
+    GenerationResponse:
+      description: A request returns a generation.
       content:
         application/json:
           schema:
             type: object
             properties:
-              data:
+              generation:
                 $ref: '#/components/schemas/Incremental'
+
+    OrderResponse:
+      description: A request returns an order.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              order:
+                $ref: '#/components/schemas/Incremental'
+
 
     PhaseListResponse:
       description: A request returns a phase list.
@@ -402,7 +413,7 @@ paths:
         $ref: '#/components/requestBodies/PhaseListRequest'
       responses:
         '201':
-          $ref: '#/components/responses/IncrementalResponse'
+          $ref: '#/components/responses/GenerationResponse'
 
   /impacttypes:
     get:
@@ -581,15 +592,15 @@ paths:
         $ref: '#/components/requestBodies/IncidentUpdateRequest'
       responses:
         '201':
-          $ref: '#/components/responses/IncrementalResponse'
+          $ref: '#/components/responses/OrderResponse'
 
-  /incidents/{incidentId}/updates/{updateId}:
+  /incidents/{incidentId}/updates/{updateOrder}:
     get:
       summary: Get a specific update from a specific incident.
       operationId: getIncidentUpdate
       parameters:
         - $ref: '#/components/parameters/IncidentIdPathParameter'
-        - $ref: '#/components/parameters/IncidentUpdateIdPathParameter'
+        - $ref: '#/components/parameters/IncidentUpdateOrderPathParameter'
       responses:
         '200':
           $ref: '#/components/responses/IncidentUpdateResponse'
@@ -599,7 +610,7 @@ paths:
       operationId: updateIncidentUpdate
       parameters:
         - $ref: '#/components/parameters/IncidentIdPathParameter'
-        - $ref: '#/components/parameters/IncidentUpdateIdPathParameter'
+        - $ref: '#/components/parameters/IncidentUpdateOrderPathParameter'
       requestBody:
         $ref: '#/components/requestBodies/IncidentUpdateRequest'
       responses:
@@ -611,7 +622,7 @@ paths:
       operationId: deleteIncidentUpdate
       parameters:
         - $ref: '#/components/parameters/IncidentIdPathParameter'
-        - $ref: '#/components/parameters/IncidentUpdateIdPathParameter'
+        - $ref: '#/components/parameters/IncidentUpdateOrderPathParameter'
       responses:
         '204':
           description: Successful. No Content

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6,7 +6,7 @@ components:
   schemas:
     # common values
     Id:
-      description: Identfication for objects. UUID prefered.
+      description: Identification for objects. UUID preferred.
       type: string
       readOnly: true
 
@@ -27,11 +27,11 @@ components:
       type: string
 
     Description:
-      description: A longer text for detailed informations.
+      description: A longer text with detailed information.
       type: string
 
     Date:
-      description: Point in time. Nullable for open ends.
+      description: Point in time. Nullable for open end timeframes.
       type: string
       format: date-time
       nullable: true

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -33,6 +33,7 @@ components:
       properties:
         id:
           type: string
+          readOnly: true
         displayName:
           type: string
         labels:
@@ -54,6 +55,7 @@ components:
       properties:
         id:
           type: string
+          readOnly: true
         title:
           type: string
         description:
@@ -89,6 +91,22 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/IncidentPhase'
+    put:
+      summary: Create a new list of phases.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/IncidentPhase'
+      responses:
+        '200':
+          description:  OK
+          content:
+            application/json:
+              schema:
+                type: boolean
   /impacttypes:
     get:
       responses:
@@ -100,6 +118,22 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/IncidentImpactType'
+  /impacttype:
+    post:
+      summary: Create a new impact type
+      operationId: createImpactType
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IncidentImpactType'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: string
   /component/{componentId}:
     get:
       summary: get specific component by id
@@ -128,6 +162,22 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Component'
+  /component:
+    post:
+      summary: Create a new component
+      operationId: createComponent
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Component'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: string
   /incident/{incidentId}:
     get:
       summary: Get specific incident by id
@@ -174,3 +224,19 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Incident'
+  /incident:
+    post:
+      summary: create a new incident
+      operationId: createIncident
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Incident'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6,19 +6,29 @@ components:
   schemas:
     Id:
       type: string
+      readOnly: true
+    IdList:
+      type: array
+      items:
+        $ref: '#/components/schemas/Id'
     IncidentImpactType:
       type: string
     IncidentPhase:
       type: string
     IncidentUpdate:
       type: object
-      required: [text, createdAt]
       properties:
+        id:
+          $ref: '#/components/schemas/Id'
         text:
           type: string
         createdAt:
           type: string
           format: date-time
+      required:
+        - id
+        - text
+        - createdAt
     Labels:
       type: object
       additionalProperties:
@@ -33,9 +43,9 @@ components:
         labels:
           $ref: '#/components/schemas/Labels'
         affectedBy:
-          type: array
-          items:
-            $ref: '#/components/schemas/Id'
+          $ref: '#/components/schemas/IdList'
+      required:
+        - id
     Incident:
       type: object
       properties:
@@ -46,13 +56,9 @@ components:
         description:
           type: string
         updates:
-          type: array
-          items:
-            $ref: '#/components/schemas/IncidentUpdate'
+          $ref: '#/components/schemas/IdList'
         affects:
-          type: array
-          items:
-            $ref: '#/components/schemas/Id'
+          $ref: '#/components/schemas/IdList'
         beganAt:
           type: string
           format: date-time
@@ -64,6 +70,8 @@ components:
           $ref: '#/components/schemas/IncidentImpactType'
         phase:
           $ref: '#/components/schemas/IncidentPhase'
+      required:
+        - id
   requestBodies:
     ComponentRequest:
       description: Send a component
@@ -77,6 +85,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Incident'
+    IncidentUpdateRequest:
+      description: Send an incident update
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/IncidentUpdate'
   responses:
     SuccessResponse:
       description: A request has successfully run
@@ -90,6 +104,25 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Id'
+  parameters:
+    ComponentIdPathParameter:
+      name: componentId
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/Id'
+    IncidentIdPathParameter:
+      name: incidentId
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/Id'
+    IncidentUpdateIdPathParameter:
+      name: updateId
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/Id'
 paths:
   /phases:
     get:
@@ -173,11 +206,7 @@ paths:
       summary: Get specific component by id
       operationId: getComponent
       parameters:
-      - in: path
-        name: componentId
-        required: true
-        schema:
-          $ref: '#/components/schemas/Id'
+      - $ref: '#/components/parameters/ComponentIdPathParameter'
       responses:
         '200':
           description: OK
@@ -189,11 +218,7 @@ paths:
       summary: Delete a component
       operationId: deleteComponent
       parameters:
-        - name: componentId
-          in: path
-          required: true
-          schema:
-            $ref: '#/components/schemas/Id'
+        - $ref: '#/components/parameters/ComponentIdPathParameter'
       responses:
         '200':
           $ref: "#/components/responses/SuccessResponse"
@@ -201,11 +226,7 @@ paths:
       summary: Fully or partially change a component
       operationId: updateComponent
       parameters:
-      - in: path
-        name: componentId
-        required: true
-        schema:
-          $ref: '#/components/schemas/Id'
+      - $ref: '#/components/parameters/ComponentIdPathParameter'
       requestBody:
         $ref: '#/components/requestBodies/ComponentRequest'
       responses:
@@ -253,11 +274,7 @@ paths:
       summary: Get specific incident by id
       operationId: getIncident
       parameters:
-      - in: path
-        name: incidentId
-        required: true
-        schema:
-          $ref: '#/components/schemas/Id'
+      - $ref: '#/components/parameters/IncidentIdPathParameter'
       responses:
         '200':
           description: OK
@@ -269,11 +286,7 @@ paths:
       summary: Delete a incident
       operationId: deleteIncident
       parameters:
-        - name: incidentId
-          in: path
-          required: true
-          schema:
-            $ref: '#/components/schemas/Id'
+        - $ref: '#/components/parameters/IncidentIdPathParameter'
       responses:
         '200':
           $ref: "#/components/responses/SuccessResponse"
@@ -281,13 +294,68 @@ paths:
       summary: Fully or partially change a incident
       operationId: updateIncident
       parameters:
-        - name: incidentId
-          in: path
-          required: true
-          schema:
-            $ref: '#/components/schemas/Id'
+        - $ref: '#/components/parameters/IncidentIdPathParameter'
       requestBody:
         $ref: '#/components/requestBodies/IncidentRequest'
+      responses:
+        '200':
+          $ref: "#/components/responses/SuccessResponse"
+  /incidents/{incidentId}/updates:
+    get:
+      summary: Get updates of a specific incident
+      operationId: getIncidentUpdates
+      parameters:
+        - $ref: '#/components/parameters/IncidentIdPathParameter'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/IncidentUpdate'
+    post:
+      summary: Create a new update to a specific incident
+      operationId: createIncidentUpdate
+      parameters:
+        - $ref: '#/components/parameters/IncidentIdPathParameter'
+      requestBody:
+        $ref: '#/components/requestBodies/IncidentUpdateRequest'
+      responses:
+        '201':
+          $ref: '#/components/responses/IdResponse'
+  /incidents/{incidentId}/updates/{updateId}:
+    get:
+      summary: Get a specific update from a specific incident
+      operationId: getIncidentUpdate
+      parameters:
+        - $ref: '#/components/parameters/IncidentIdPathParameter'
+        - $ref: '#/components/parameters/IncidentUpdateIdPathParameter'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IncidentUpdate'
+    delete:
+      summary: Delete a specific update from a specific incident
+      operationId: deleteIncidentUpdate
+      parameters:
+        - $ref: '#/components/parameters/IncidentIdPathParameter'
+        - $ref: '#/components/parameters/IncidentUpdateIdPathParameter'
+      responses:
+        '200':
+          $ref: "#/components/responses/SuccessResponse"
+    patch:
+      summary: Update a specific update from a specific incident
+      operationId: updateIncidentUpdate
+      parameters:
+        - $ref: '#/components/parameters/IncidentIdPathParameter'
+        - $ref: '#/components/parameters/IncidentUpdateIdPathParameter'
+      requestBody:
+        $ref: '#/components/requestBodies/IncidentUpdateRequest'
       responses:
         '200':
           $ref: "#/components/responses/SuccessResponse"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -25,15 +25,9 @@ components:
         type: string
     Component:
       type: object
-      required:
-        - id
-        - displayName
-        - labels
-        - affectedBy
       properties:
         id:
           type: string
-          readOnly: true
         displayName:
           type: string
         labels:
@@ -44,18 +38,9 @@ components:
             $ref: '#/components/schemas/Id'
     Incident:
       type: object
-      required:
-        - id
-        - title
-        - description
-        - updates
-        - affects
-        - impactType
-        - phase
       properties:
         id:
           type: string
-          readOnly: true
         title:
           type: string
         description:
@@ -135,7 +120,7 @@ paths:
                 type: string
   /impacttypes/{impactType}:
     delete:
-      summary: Delete a impact type
+      summary: Delete an impact type
       operationId: deleteImpactType
       parameters:
         - name: impactType
@@ -202,6 +187,27 @@ paths:
           required: true
           schema:
             type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: boolean
+    patch:
+      summary: Fully or partially change a component
+      operationId: updateComponent
+      parameters:
+      - in: path
+        name: componentId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Component'
       responses:
         '200':
           description: OK
@@ -279,6 +285,27 @@ paths:
           required: true
           schema:
             type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: boolean
+    patch:
+      summary: Fully or partially change a incident
+      operationId: updateIncident
+      parameters:
+        - name: incidentId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Incident'
       responses:
         '200':
           description: OK

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -70,6 +70,32 @@ components:
           $ref: '#/components/schemas/IncidentImpactType'
         phase:
           $ref: '#/components/schemas/IncidentPhase'
+  requestBodies:
+    ComponentRequest:
+      description: Send a component
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Component'
+    IncidentRequest:
+      description: Send an incident
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Incident'
+  responses:
+    SuccessResponse:
+      description: A request has successfully run
+      content:
+        application/json:
+          schema:
+            type: boolean
+    IdResponse:
+      description: A request returns an ID
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Id'
 paths:
   /phases:
     get:
@@ -93,11 +119,7 @@ paths:
                 $ref: '#/components/schemas/IncidentPhase'
       responses:
         '200':
-          description:  OK
-          content:
-            application/json:
-              schema:
-                type: boolean
+          $ref: "#/components/responses/SuccessResponse"
   /impacttypes:
     get:
       responses:
@@ -119,11 +141,7 @@ paths:
               $ref: '#/components/schemas/IncidentImpactType'
       responses:
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                type: string
+          $ref: '#/components/responses/IdResponse'
   /impacttypes/{impactType}:
     delete:
       summary: Delete an impact type
@@ -136,11 +154,7 @@ paths:
             $ref: '#/components/schemas/IncidentImpactType'
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: boolean
+          $ref: "#/components/responses/SuccessResponse"
   /components:
     get:
       responses:
@@ -156,17 +170,10 @@ paths:
       summary: Create a new component
       operationId: createComponent
       requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Component'
+        $ref: '#/components/requestBodies/ComponentRequest'
       responses:
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                type: string
+          $ref: '#/components/responses/IdResponse'
   /components/{componentId}:
     get:
       summary: Get specific component by id
@@ -195,11 +202,7 @@ paths:
             type: string
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: boolean
+          $ref: "#/components/responses/SuccessResponse"
     patch:
       summary: Fully or partially change a component
       operationId: updateComponent
@@ -210,17 +213,10 @@ paths:
         schema:
           type: string
       requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Component'
+        $ref: '#/components/requestBodies/ComponentRequest'
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: boolean
+          $ref: "#/components/responses/SuccessResponse"
   /incidents:
     get:
       summary: Get list of incidents
@@ -254,17 +250,10 @@ paths:
       summary: Create a new incident
       operationId: createIncident
       requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Incident'
+        $ref: '#/components/requestBodies/IncidentRequest'
       responses:
         '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                type: string
+          $ref: '#/components/responses/IdResponse'
   /incidents/{incidentId}:
     get:
       summary: Get specific incident by id
@@ -293,11 +282,7 @@ paths:
             type: string
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: boolean
+          $ref: "#/components/responses/SuccessResponse"
     patch:
       summary: Fully or partially change a incident
       operationId: updateIncident
@@ -308,14 +293,7 @@ paths:
           schema:
             type: string
       requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Incident'
+        $ref: '#/components/requestBodies/IncidentRequest'
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: boolean
+          $ref: "#/components/responses/SuccessResponse"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -70,7 +70,7 @@ components:
       description: |
         A single phase is just its name.
         It can be referenced by its generation and order.
-        See: #/components/schemas/DisplayName
+        See: #/components/schemas/PhaseReference
       type: string
 
     PhaseReference:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,7 +4,7 @@ info:
   version: '1.0'
 components:
   schemas:
-    # common values
+    # common definitions
     Id:
       description: Identification for objects. UUID preferred.
       type: string

--- a/pkg/api/api.gen.go
+++ b/pkg/api/api.gen.go
@@ -58,6 +58,18 @@ type IncidentUpdate struct {
 // Labels defines model for Labels.
 type Labels map[string]string
 
+// IdResponse defines model for IdResponse.
+type IdResponse = Id
+
+// SuccessResponse defines model for SuccessResponse.
+type SuccessResponse = bool
+
+// ComponentRequest defines model for ComponentRequest.
+type ComponentRequest = Component
+
+// IncidentRequest defines model for IncidentRequest.
+type IncidentRequest = Incident
+
 // GetIncidentsParams defines parameters for GetIncidents.
 type GetIncidentsParams struct {
 	// Start Start of time frame to query for (RFC3339)
@@ -391,22 +403,24 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/9RYUY/iNhD+K5bbh1bKQmD70rzd0d4J9dRD3etLT/swxBPwKbF9ttM2Qvz3yjaQhGQh",
-	"dHfZPYmHxJnMfPPNN5MRG5rKQkmBwhqabKhJ11iAv5ztH7gbpaVCbTn6R5BlmFpkbyt3xy0W/vh7jRlN",
-	"6Hfj2ud453A8Z3QbUVsppAkFraFy94wblUP1OxToHOweG6u5WLnnnLljjcA+iryiidUlRl2zHJaYn4Xw",
-	"IVhttxHV+LXkGhlNPrsY9wefcvkFU+t8zlkvorlIOTtBinkkI0tcgXjj3WdSF2BpQhlYvLG8QNqTO0OT",
-	"aq4sl6IXMAqG7IRDUeY5LHN8kNyBNeCFgtR+8sdnEt9ROK/f2EZUrcEMfnXhjR193Ob90imVy/KCcuxc",
-	"/+nf65ZmoGq6uZ1S0WKf9IMWOzgdtaUawZ4sbMelxX9tT6yjxLxV1PDfl+aHQ8MBY9xpD/JFC183etuH",
-	"C8tFJr1tKCK9m92ROwu2NGQBKyRvFnMa0b9RGy9uOhnFzpNUKEBxmtDbUTya0ogqsGsfddyeZiv0CTtc",
-	"4EC6nqbv0c5qK5e8UVKYAHsax55dKeyuyUGpnKf+9fEXE5osaGawtOpJ2lXVcQfTj7+FUyVND/iZL0vt",
-	"MNQOjX0rWXUR8oGAt0EfLYomFwU6llsn45AT80o0ZVGArg6nBIjAf0jaABQ1qzzeHK7nbOvCMcwxNEyb",
-	"uV/8eZM5BRoKtKgNTT5vKHdYnJLcUPQfJNrwTZtdEkbgwyneP1JVO39LKXME8aBKmnSF9Ag0qYrON8Cr",
-	"pmGwRM+y8x4tMQpTnvG0ZogsK8L9V1iBTdddpsLwvSJZV2/lZ9fluzLPKyI1UaAtB3eTrkGsjqTqujps",
-	"EC7GyeE9b5hdY3r3rytPMcYbHp+n+H3QX8dAD7UmNkBqF3+8qXfJASO9xeL5/uTHpPe358W0vuDMFz10",
-	"7iCe7qSDUYe4duQ7C9oSmRG3WpLMWRIrydcSdUUyqckPf7yb3d7e/vwjjQLn/lFNunEOTvLNMIMydzvs",
-	"NJ5Ob+LJTTz5NIkT/xvFk/gvGg3ac7fRMfpfBXsMdhRsOPKfHoP8/prjbPAQO/6O5tx4LdQSOzfm9hGf",
-	"d8i9mtFW42k24nizvxy0qDZIGzDTDp6/mTWVN2R4bj69Zg6GKvOyFXWfzMAN9WpEXbt7X3Q9bTey/3/q",
-	"5Od0ESyuOcTr/8GGrqNlD/ZF2cT+/2r8NLBfQAGt2b3/toVijzyk/wIAAP//ugwDgiMXAAA=",
+	"H4sIAAAAAAAC/8xYzY7bNhB+FYLtoQW0luztpbptnCYwGjTGOr002AMtjmwGEsUlqbaCoXcvSNrWr2Xt",
+	"ru0U8EGiRjPffPNr7XCUpSLjwLXC4Q5LeM5B6XcZZWAP5ofHj+6JOYsyroHbSyJEwiKiWcb9byrj5kxF",
+	"W0iJufpRQoxD/INfGfHdU+UfFeOyLD1MQUWSCaMIh3gFnCKCokrGwwseMXoFIAe9p3FwxCoZD0tQIuPK",
+	"8bOgj/vbywGifVAe0D42SILOJVcG1+K9YWaVRxEo9SoguhCAQ7zOsgQIHza8JQopZyvOk6RAMueWkT3y",
+	"Rr6YGyEzAVLvU4nEMUQa6LvC3DENqRpDhXfASKQkhbmnTImEFH+QFGouKC0Z35jnjLpUJvQzTwocapmD",
+	"1xVLyBqSsxA+OSkX+OecSaA4/GpsPB11ZutvELkkpb2Ijjl2ghT1RkbWsCH8waqPM5kSjUNMiYY7zVLA",
+	"Pb43QtwDGDgFOqCQ50lC1gmcJHdkDFgqSKS/2ONxZbqo3ig9LLZEjX51aYUNfUwn/amTC+PlC8KxV/2n",
+	"fa8bmpFZ0/VtKIuWB6dPSuzhdLItkkD0YGA7KjX8q3tstRyzUl5Nf5+bn44FRyhlJvdIsmzg61pv6jBm",
+	"GY8zK+uCiFfzFVpponOFlmQD6GG5wB7+G6Ry/Ws6CYymTAAnguEQ30+CyQx7WBC9tVb95gzcgHXY4LJd",
+	"09Q0/gh6Xkm1hsAsCF7UdEel1rw+/FpZ1WnSn393pyJTPeDnNiyVQq8254tTOBqrgN/ZA8oOB9PTmvZy",
+	"fm1a2rmRpymRxREhIojDP/WxX3r16Pi74/WClsYchQRcojc9fm/P6x4LIkkKGqTC4dcdZoY1kwGmmdlB",
+	"gmu6cT27XevqjMxjJTz1Z8MwE+2Z3aTDwW9vQGcT83u4ef1l0OZ2nZ2PoJESELGYRRVDaF0gZqejIDra",
+	"dplyTfGGZF2+xN6cWB/s3pZJJIjUjJibaEv4ppVrpuzcaDaODXbFRU3sFm2xfw+4RH+saexE76L/NOrQ",
+	"y/KKjdSFEGlnqRlTf1ftXiNaaYOc83XD2lz2l82L2bpir+U9dO0hDBfAUahDTOvPpCZSoyxGZtVCsZFE",
+	"OkPPOcgCxZlEPz1+mN/f3//6M/Ycp/ZRRaoyCgb5pBCTPDE73SyYze6C6V0w/TINQvubBNPgL+yN2vtK",
+	"r43+N07fgh04HY/8l7cgf7plFxrde9rzK2HK5kKVYue608HiKyZL+9PJNVtO/UtJVUD+7nA5anGrOTui",
+	"1xw1/2/WNlZLj3N94zv4ePXvZsMr28GZkRvbzYi6eFVddV1rVpr9EDI4p5ZO4pbdsfrgMnY9y3uwL/M6",
+	"9tetZZeBfYUIN5rnYSi4YE6syf8CAAD//1+2pLOiFwAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/api/api.gen.go
+++ b/pkg/api/api.gen.go
@@ -123,7 +123,7 @@ type Labels map[string]string
 
 // Phase A single phase is just its name.
 // It can be referenced by its generation and order.
-// See: #/components/schemas/DisplayName
+// See: #/components/schemas/PhaseReference
 type Phase = string
 
 // PhaseList Phase resources are always handled as a list.
@@ -714,21 +714,21 @@ var swaggerSpec = []string{
 	"mr9oIjIiBE5We1uFwju2YOEJo0n8KkmsOKjJF+nW1mTLElQSIQkjG/EC5YgGZYUKmDknQN8jhyz6a2Lm",
 	"Jgg8aztCWMzQottaGPECzvH5SKtu6W4FygkVroO/2UEYqkLH4jWByWZSCbx2EenQMCENbEAhso/F9oRx",
 	"LnA+Fi0rcWzoXhW9m4AwBWStAJzs/wf25IVFKZCECeXUoXSsJ9ili5Z52dWVRgu5iYDYssQM/5ZqY/PT",
-	"aj9mNAmZJCsghUjatMYhG5CgnJfQb3muPgPMSV96WAc2jLcw20XRPiojYF3Cole2x7KRHDdADAsUpbOp",
-	"8CXUs9Ix4ys7xSB1dH5uiGMtrT00xQpfu6L25G9Oqj75FJdRIcwFMegMDYZXAnC3Aavp88U1frFnb0YO",
-	"HoKmE/El3BjbWhMG9930+eGZPBtmUk2WbAPkw3JBA4obIefWu8nMAkxAskTQOX0/mU3u0WfMbK27ptVO",
-	"4QZswqJDLQ7cHtN/gnkoR9WOx/ez2VmnvUHJ5zVaGgnYYJbf/uUOgOlux9Te4c3KBznP5xMsg1i3mPhg",
-	"ablc1u8qdR4VK42naaPrdGx46q57pmzc1Os2VI1yCAkjEl4rTaZj4AdxevC6r0dXaBG47UDV5Ef7u2+y",
-	"3yb+vR1oOWTa2UY+fm1PkdOG1zsIVesd2EZ7rTddv7dVneF0OaoTCPGg6R1nUJG4y1Rmwm3TPLfFGs3C",
-	"22f91cF3FteCj2nvDpXIDyfJqzzOvQ17+Sfmq+nLO+73E5i38gWxbDarR6Swame6Fs3pwb+UGUBjFcPP",
-	"q4fuK6YxiazZmu/P3jcw7Q2uJjryvaBCzy9DyXBEF41QQrfjwzaf5cWUHdRPE2MxqOG2Wk/VMGXZyIgd",
-	"nt/YzrYM/khB7e2h7aenfzy8f//+bz8Xt372WXntp3GGk3d+HNYsjQyd0/vZ/f272d272d2nu9nc/pvM",
-	"7mb/7mpE1w5fx6AO/+94cLgCPEg+HPpfr4H+9U30qbisu16d8gwiKzCvAJKY15gkscCf8iuGXtXK8VxS",
-	"cLULzTEVq7y/rFTY9FBeyw+RqtLaM6mq49uCkWXKv7XtI5LRbRr9srpXnfIG6FBpGsczN6+Sm4mSHFYn",
-	"U68P3pdVWVP5x0mus1g2/wbhaq7NPEbWKt61peRgns0Q/RAZWf3+Y0T2zq4+7OVhm+v6U3V6yL9dOoPl",
-	"b+3rYPCr7V92jdqcKfyaObsrU4dIyf+L497oe6U+Xerx+HCh+jH9PhK7jHAU6w8EMk15GdNVB+UFUiMU",
-	"bUeUykXMJd99jZnepS1DM9tsgYSpUrjT8m6Acil07usVPN+HtRy6vV2XaVfLd30nRMxzBZ5nt/l1p7sq",
-	"RBD/CwAA///OXjTp+y0AAA==",
+	"aj9mNAmZJCsghUjatMYhG5CgnJfQb3muPgPMyYC6tj5s2G/HtOuifVQGwXqFRa9sj5UjOe6BGNYoqmdT",
+	"5Eu0Z2VkRll2ikEC6Vzd0MdaZntoihW+dgXuyd+fVH3yKS4DQ5iLY9AZHYywBOBuD1aT6IvL/GLP3owf",
+	"PARNJ+JLuDe25SYMbr3p88MzeTbMpJos2QbIh+WCBhT3Qs6td5OZBZiAZImgc/p+Mpvco8+Y2Vp3TavN",
+	"wg3YhEWHWhy4Q6b/BPNQjqqdkO9ns7MOfIOSz+u1NBKwQS6//cudAdPdjqm9w5uVD9KeTylYBrFuMfHB",
+	"MnO5rN9Y6jwtVnpP00bj6djw1F33TNm4qddwqBrlEBJGJLxW+kzHwA/i9OA1YI+u0CJwO4KqyY/2d99k",
+	"v1P8ezvQcsi0s5N8/NqeIqcNrzcRqtY7sI0OW2+6fm+rOsPpclQnEOJZ0zvRoChxl6nMhNumeW6XNZqF",
+	"t8/6q4PvLK4FH9PenSuRH06SV3miexv28g/NV9OXd+LvJzBv5Qti2exXj0hh1eZ0LZrTg38vM4DGKoaf",
+	"Vw/dt0xjElmzO9+fvW9g2hvcTnTke0GFnl+GkuGILhqhhG7Hh20+y4spO6ufJsZiUMNttbaqYcqykRE7",
+	"PMKxne0a/JGC2ttz209P/3h4//79334uLv7ss/LmT+MMJ6/9OKxZGhk6p/ez+/t3s7t3s7tPd7O5/TeZ",
+	"3c3+3dWLrh2+jkEd/t/x4HAFeJB8OPS/XgP965voU3Ffd7065RlEVmBeASQxrzFJYoE/5bcMvaqV47mk",
+	"4Gp3mmMqVnmFWamw6aG8mR8iVaW1Z1JVx+cFI8uUf3HbRySj2zT6fXWvOuU90KHSNI5nbl4lNxMlOaxO",
+	"pl4rvC+rsr7yj5NcZ7Fs/hnC1VybeYysVbxrS8nBPJsh+iEysvoJyIjsnd1+2PvDNtf1p+r0kH++dAbL",
+	"39rXweBX2z/uGrU5U/g1c3ZXpg6Rkv8Xx73RJ0t9utTj8eFC9WP6fSR2GeEo1h8IZJryMqarDsoLpEYo",
+	"2o4olYuYSz79GjO9S1uGZrbZAglTpXCn5d0A5VLo3NcreL4Pazl0e7su066WT/tOiJjnCjzPbvMbT3dV",
+	"iCD+FwAA///uLJ3G/i0AAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/api/api.gen.go
+++ b/pkg/api/api.gen.go
@@ -21,7 +21,7 @@ import (
 
 // Component defines model for Component.
 type Component struct {
-	AffectedBy  *[]Id   `json:"affectedBy,omitempty"`
+	AffectedBy  *IdList `json:"affectedBy,omitempty"`
 	DisplayName *string `json:"displayName,omitempty"`
 	Id          *Id     `json:"id,omitempty"`
 	Labels      *Labels `json:"labels,omitempty"`
@@ -30,9 +30,12 @@ type Component struct {
 // Id defines model for Id.
 type Id = string
 
+// IdList defines model for IdList.
+type IdList = []Id
+
 // Incident defines model for Incident.
 type Incident struct {
-	Affects     *[]Id               `json:"affects,omitempty"`
+	Affects     *IdList             `json:"affects,omitempty"`
 	BeganAt     *time.Time          `json:"beganAt,omitempty"`
 	Description *string             `json:"description,omitempty"`
 	EndedAt     *time.Time          `json:"endedAt"`
@@ -40,7 +43,7 @@ type Incident struct {
 	ImpactType  *IncidentImpactType `json:"impactType,omitempty"`
 	Phase       *IncidentPhase      `json:"phase,omitempty"`
 	Title       *string             `json:"title,omitempty"`
-	Updates     *[]IncidentUpdate   `json:"updates,omitempty"`
+	Updates     *IdList             `json:"updates,omitempty"`
 }
 
 // IncidentImpactType defines model for IncidentImpactType.
@@ -52,11 +55,21 @@ type IncidentPhase = string
 // IncidentUpdate defines model for IncidentUpdate.
 type IncidentUpdate struct {
 	CreatedAt time.Time `json:"createdAt"`
+	Id        *Id       `json:"id,omitempty"`
 	Text      string    `json:"text"`
 }
 
 // Labels defines model for Labels.
 type Labels map[string]string
+
+// ComponentIdPathParameter defines model for ComponentIdPathParameter.
+type ComponentIdPathParameter = Id
+
+// IncidentIdPathParameter defines model for IncidentIdPathParameter.
+type IncidentIdPathParameter = Id
+
+// IncidentUpdateIdPathParameter defines model for IncidentUpdateIdPathParameter.
+type IncidentUpdateIdPathParameter = Id
 
 // IdResponse defines model for IdResponse.
 type IdResponse = Id
@@ -69,6 +82,9 @@ type ComponentRequest = Component
 
 // IncidentRequest defines model for IncidentRequest.
 type IncidentRequest = Incident
+
+// IncidentUpdateRequest defines model for IncidentUpdateRequest.
+type IncidentUpdateRequest = IncidentUpdate
 
 // GetIncidentsParams defines parameters for GetIncidents.
 type GetIncidentsParams struct {
@@ -97,6 +113,12 @@ type CreateIncidentJSONRequestBody = Incident
 // UpdateIncidentJSONRequestBody defines body for UpdateIncident for application/json ContentType.
 type UpdateIncidentJSONRequestBody = Incident
 
+// CreateIncidentUpdateJSONRequestBody defines body for CreateIncidentUpdate for application/json ContentType.
+type CreateIncidentUpdateJSONRequestBody = IncidentUpdate
+
+// UpdateIncidentUpdateJSONRequestBody defines body for UpdateIncidentUpdate for application/json ContentType.
+type UpdateIncidentUpdateJSONRequestBody = IncidentUpdate
+
 // PutPhasesJSONRequestBody defines body for PutPhases for application/json ContentType.
 type PutPhasesJSONRequestBody = PutPhasesJSONBody
 
@@ -110,13 +132,13 @@ type ServerInterface interface {
 	CreateComponent(ctx echo.Context) error
 	// Delete a component
 	// (DELETE /components/{componentId})
-	DeleteComponent(ctx echo.Context, componentId Id) error
+	DeleteComponent(ctx echo.Context, componentId ComponentIdPathParameter) error
 	// Get specific component by id
 	// (GET /components/{componentId})
-	GetComponent(ctx echo.Context, componentId Id) error
+	GetComponent(ctx echo.Context, componentId ComponentIdPathParameter) error
 	// Fully or partially change a component
 	// (PATCH /components/{componentId})
-	UpdateComponent(ctx echo.Context, componentId Id) error
+	UpdateComponent(ctx echo.Context, componentId ComponentIdPathParameter) error
 
 	// (GET /impacttypes)
 	GetImpacttypes(ctx echo.Context) error
@@ -134,13 +156,28 @@ type ServerInterface interface {
 	CreateIncident(ctx echo.Context) error
 	// Delete a incident
 	// (DELETE /incidents/{incidentId})
-	DeleteIncident(ctx echo.Context, incidentId Id) error
+	DeleteIncident(ctx echo.Context, incidentId IncidentIdPathParameter) error
 	// Get specific incident by id
 	// (GET /incidents/{incidentId})
-	GetIncident(ctx echo.Context, incidentId Id) error
+	GetIncident(ctx echo.Context, incidentId IncidentIdPathParameter) error
 	// Fully or partially change a incident
 	// (PATCH /incidents/{incidentId})
-	UpdateIncident(ctx echo.Context, incidentId Id) error
+	UpdateIncident(ctx echo.Context, incidentId IncidentIdPathParameter) error
+	// Get updates of a specific incident
+	// (GET /incidents/{incidentId}/updates)
+	GetIncidentUpdates(ctx echo.Context, incidentId IncidentIdPathParameter) error
+	// Create a new update to a specific incident
+	// (POST /incidents/{incidentId}/updates)
+	CreateIncidentUpdate(ctx echo.Context, incidentId IncidentIdPathParameter) error
+	// Delete a specific update from a specific incident
+	// (DELETE /incidents/{incidentId}/updates/{updateId})
+	DeleteIncidentUpdate(ctx echo.Context, incidentId IncidentIdPathParameter, updateId IncidentUpdateIdPathParameter) error
+	// Get a specific update from a specific incident
+	// (GET /incidents/{incidentId}/updates/{updateId})
+	GetIncidentUpdate(ctx echo.Context, incidentId IncidentIdPathParameter, updateId IncidentUpdateIdPathParameter) error
+	// Update a specific update from a specific incident
+	// (PATCH /incidents/{incidentId}/updates/{updateId})
+	UpdateIncidentUpdate(ctx echo.Context, incidentId IncidentIdPathParameter, updateId IncidentUpdateIdPathParameter) error
 
 	// (GET /phases)
 	GetPhases(ctx echo.Context) error
@@ -176,7 +213,7 @@ func (w *ServerInterfaceWrapper) CreateComponent(ctx echo.Context) error {
 func (w *ServerInterfaceWrapper) DeleteComponent(ctx echo.Context) error {
 	var err error
 	// ------------- Path parameter "componentId" -------------
-	var componentId Id
+	var componentId ComponentIdPathParameter
 
 	err = runtime.BindStyledParameterWithLocation("simple", false, "componentId", runtime.ParamLocationPath, ctx.Param("componentId"), &componentId)
 	if err != nil {
@@ -192,7 +229,7 @@ func (w *ServerInterfaceWrapper) DeleteComponent(ctx echo.Context) error {
 func (w *ServerInterfaceWrapper) GetComponent(ctx echo.Context) error {
 	var err error
 	// ------------- Path parameter "componentId" -------------
-	var componentId Id
+	var componentId ComponentIdPathParameter
 
 	err = runtime.BindStyledParameterWithLocation("simple", false, "componentId", runtime.ParamLocationPath, ctx.Param("componentId"), &componentId)
 	if err != nil {
@@ -208,7 +245,7 @@ func (w *ServerInterfaceWrapper) GetComponent(ctx echo.Context) error {
 func (w *ServerInterfaceWrapper) UpdateComponent(ctx echo.Context) error {
 	var err error
 	// ------------- Path parameter "componentId" -------------
-	var componentId Id
+	var componentId ComponentIdPathParameter
 
 	err = runtime.BindStyledParameterWithLocation("simple", false, "componentId", runtime.ParamLocationPath, ctx.Param("componentId"), &componentId)
 	if err != nil {
@@ -292,7 +329,7 @@ func (w *ServerInterfaceWrapper) CreateIncident(ctx echo.Context) error {
 func (w *ServerInterfaceWrapper) DeleteIncident(ctx echo.Context) error {
 	var err error
 	// ------------- Path parameter "incidentId" -------------
-	var incidentId Id
+	var incidentId IncidentIdPathParameter
 
 	err = runtime.BindStyledParameterWithLocation("simple", false, "incidentId", runtime.ParamLocationPath, ctx.Param("incidentId"), &incidentId)
 	if err != nil {
@@ -308,7 +345,7 @@ func (w *ServerInterfaceWrapper) DeleteIncident(ctx echo.Context) error {
 func (w *ServerInterfaceWrapper) GetIncident(ctx echo.Context) error {
 	var err error
 	// ------------- Path parameter "incidentId" -------------
-	var incidentId Id
+	var incidentId IncidentIdPathParameter
 
 	err = runtime.BindStyledParameterWithLocation("simple", false, "incidentId", runtime.ParamLocationPath, ctx.Param("incidentId"), &incidentId)
 	if err != nil {
@@ -324,7 +361,7 @@ func (w *ServerInterfaceWrapper) GetIncident(ctx echo.Context) error {
 func (w *ServerInterfaceWrapper) UpdateIncident(ctx echo.Context) error {
 	var err error
 	// ------------- Path parameter "incidentId" -------------
-	var incidentId Id
+	var incidentId IncidentIdPathParameter
 
 	err = runtime.BindStyledParameterWithLocation("simple", false, "incidentId", runtime.ParamLocationPath, ctx.Param("incidentId"), &incidentId)
 	if err != nil {
@@ -333,6 +370,110 @@ func (w *ServerInterfaceWrapper) UpdateIncident(ctx echo.Context) error {
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.UpdateIncident(ctx, incidentId)
+	return err
+}
+
+// GetIncidentUpdates converts echo context to params.
+func (w *ServerInterfaceWrapper) GetIncidentUpdates(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "incidentId" -------------
+	var incidentId IncidentIdPathParameter
+
+	err = runtime.BindStyledParameterWithLocation("simple", false, "incidentId", runtime.ParamLocationPath, ctx.Param("incidentId"), &incidentId)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter incidentId: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.GetIncidentUpdates(ctx, incidentId)
+	return err
+}
+
+// CreateIncidentUpdate converts echo context to params.
+func (w *ServerInterfaceWrapper) CreateIncidentUpdate(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "incidentId" -------------
+	var incidentId IncidentIdPathParameter
+
+	err = runtime.BindStyledParameterWithLocation("simple", false, "incidentId", runtime.ParamLocationPath, ctx.Param("incidentId"), &incidentId)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter incidentId: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.CreateIncidentUpdate(ctx, incidentId)
+	return err
+}
+
+// DeleteIncidentUpdate converts echo context to params.
+func (w *ServerInterfaceWrapper) DeleteIncidentUpdate(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "incidentId" -------------
+	var incidentId IncidentIdPathParameter
+
+	err = runtime.BindStyledParameterWithLocation("simple", false, "incidentId", runtime.ParamLocationPath, ctx.Param("incidentId"), &incidentId)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter incidentId: %s", err))
+	}
+
+	// ------------- Path parameter "updateId" -------------
+	var updateId IncidentUpdateIdPathParameter
+
+	err = runtime.BindStyledParameterWithLocation("simple", false, "updateId", runtime.ParamLocationPath, ctx.Param("updateId"), &updateId)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter updateId: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.DeleteIncidentUpdate(ctx, incidentId, updateId)
+	return err
+}
+
+// GetIncidentUpdate converts echo context to params.
+func (w *ServerInterfaceWrapper) GetIncidentUpdate(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "incidentId" -------------
+	var incidentId IncidentIdPathParameter
+
+	err = runtime.BindStyledParameterWithLocation("simple", false, "incidentId", runtime.ParamLocationPath, ctx.Param("incidentId"), &incidentId)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter incidentId: %s", err))
+	}
+
+	// ------------- Path parameter "updateId" -------------
+	var updateId IncidentUpdateIdPathParameter
+
+	err = runtime.BindStyledParameterWithLocation("simple", false, "updateId", runtime.ParamLocationPath, ctx.Param("updateId"), &updateId)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter updateId: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.GetIncidentUpdate(ctx, incidentId, updateId)
+	return err
+}
+
+// UpdateIncidentUpdate converts echo context to params.
+func (w *ServerInterfaceWrapper) UpdateIncidentUpdate(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "incidentId" -------------
+	var incidentId IncidentIdPathParameter
+
+	err = runtime.BindStyledParameterWithLocation("simple", false, "incidentId", runtime.ParamLocationPath, ctx.Param("incidentId"), &incidentId)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter incidentId: %s", err))
+	}
+
+	// ------------- Path parameter "updateId" -------------
+	var updateId IncidentUpdateIdPathParameter
+
+	err = runtime.BindStyledParameterWithLocation("simple", false, "updateId", runtime.ParamLocationPath, ctx.Param("updateId"), &updateId)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter updateId: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.UpdateIncidentUpdate(ctx, incidentId, updateId)
 	return err
 }
 
@@ -395,6 +536,11 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.DELETE(baseURL+"/incidents/:incidentId", wrapper.DeleteIncident)
 	router.GET(baseURL+"/incidents/:incidentId", wrapper.GetIncident)
 	router.PATCH(baseURL+"/incidents/:incidentId", wrapper.UpdateIncident)
+	router.GET(baseURL+"/incidents/:incidentId/updates", wrapper.GetIncidentUpdates)
+	router.POST(baseURL+"/incidents/:incidentId/updates", wrapper.CreateIncidentUpdate)
+	router.DELETE(baseURL+"/incidents/:incidentId/updates/:updateId", wrapper.DeleteIncidentUpdate)
+	router.GET(baseURL+"/incidents/:incidentId/updates/:updateId", wrapper.GetIncidentUpdate)
+	router.PATCH(baseURL+"/incidents/:incidentId/updates/:updateId", wrapper.UpdateIncidentUpdate)
 	router.GET(baseURL+"/phases", wrapper.GetPhases)
 	router.PUT(baseURL+"/phases", wrapper.PutPhases)
 
@@ -403,24 +549,27 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/8xYTW/jNhD9KwTbQwtoIznppbplvd2F0UVrxNtLFznQ4sjmQiIZkmprGPrvBUnb+rSs",
-	"OHY2QA6WNJp582b4ZqItTkQuBQduNI63WMFTAdq8F5SBuzHdP37wT+y9RHAD3P0kUmYsIYYJHn7Tgtt7",
-	"OllDTuyvHxWkOMY/hFWQ0D/V4cExLssywBR0opi0jnCMF8ApIiipbAI84wmjVwCy93scB0essgmwAi0F",
-	"156fGX3YXV4OEO2Dco92tUEKTKG4trhmHywziyJJQOuzgJiNBBzjpRAZED4ceE000j5WWmTZBqmCO0Z2",
-	"yBv9Yi+kEhKU2bUSSVNIDND3G3vFDOR6DBXBHiNRimzsNWVaZmTzB8mhloI2ivGVfc7oOL8ZWUJ2EsNn",
-	"b1VWQMTyGyS+J2kvgENLHeFAv5CAJawIv3fuU6FyYnCMKTHwzrAccNAF1KhoD2DgFOiAQ15kGVlmgGOj",
-	"CgjOp5zlkiTmi3t93LGcVW+UAZZroke/OnfGlj9msv5WKaRN8xn12Ln+y73XrU1vk3QzGWqa+T7Foxa7",
-	"4J3mShQQM1jHjksD/5meWE7lngqmgOL4q7cKav4fe9L8fDhNhFJmW41k8wa+bvSmDxuW8VQ4W18yvJgu",
-	"0MIQU2g0JytA9/MZDvA/oLRXp8lNZD0JCZxIhmN8dxPd3OIAS2LWLmrYnHArcAlbXE4T7RHGn8BMK6uW",
-	"xN9G0bMkdVQjTeujrdVDHQn+83d/VwrdA37qylI5DGpTfHMMR2PQh50pX3Y4mBz3tLMLa7PQTYUiz4na",
-	"HBAigjj8Wx/qZVCvTrg9/J7R0oajkIFv9GbGH9z9esaSKJKDAaVx/HWLmWXNdoDVLjcmcM03rne3F7Rn",
-	"TObH/vYYpqY9opv8+HzaC8/JTn0TeV9/GXTdX6frExikJSQsZUlFGVpuEHNDRhKTrLvUedn8nuxd/lS+",
-	"uPU+ukVOKCSJMozYi2RN+KrVjfak+tlttWpQSGc1s9dQ0v5F4RKSWvPYqd5F//WoQy/LK2qvLyEyPlKz",
-	"puG2Ws5GqG+DnNMHibW5POMc9bF1RTXmPXTtIAwfgINRh5jWf5eGKINEiux2hlJriYxATwWoDUqFQj89",
-	"fJze3d39+jMOPKfuUUWqtg4G+aSQkiKza+BtdHv7Lpq8iyZfJlHs/m6iSfQ3DkatimXQRv8bpy/BDpyO",
-	"R/7LS5A/vqYKjdae9kDLmHa9ULXYKXXaRzxjsrS/pVxTcuqfTqoDFG73P0fterVkR2jNwfPb3fRYrV9O",
-	"CclbSPrqn9qGt7x9diOXvO/H3MUP4lU3vObhdB9XBkfb3Fu8pqBWH3HGbnRFD/Z5Ucd+3iZ3GdhXqHBD",
-	"b/dzxBfzxoX8PwAA///E7Ukd5hcAAA==",
+	"H4sIAAAAAAAC/8xZTW/jNhD9KwTbQwtoIzvppb5lvd2F0aBrJLuXLnKgxVHMhURqSaqtYei/FyQl69M2",
+	"/aEgQA6xNOI8vpl5M6K2OBJpJjhwrfBsizMiSQoapP01r+4t6JLo9bK6ae4xjmc4I3qNA8xJCnhWL7Wg",
+	"OMASfuRMAsUzLXMIsIrWkBLz6M8SYjzDP4W179DdVeGC4qII8IJHjHo7Zjvra/n9mlGiwc97Xtpe5rtw",
+	"T4PS7wVl0Ob/0d0x1yLBNXD7L8myhEVEM8HD70pwc83P425h55iCiiTLzEJ4hp+AU0RQVNvUvFwbSLXu",
+	"fhwcsZ1NNz5joXGr+2BCeWVqwqcywZUL3YI+lj+vh44OIbpHZdogCTqXXBl4iw+GrKc8ikCps4DoTWZy",
+	"eyVEAoQfdrwmCinnK86TZINkzi0jJfJWKluVkSIDqcssJ3EMkQb6fnOcgQembB5QprKEbP6yFbhDq7Rk",
+	"/MXcZ9SHzQAnZAWJOmb74KyqGnUV/s04eQ4q32L1HSKXo9a3BEI/82RTSUEPYrkZoykaUuWHt1yFSEk2",
+	"zXrYx6ryp3QFL4Tf25ViIVOi8Qyb3H6nWQp4YAOtdBiIAXAK9MCCPE8SskpgL0O+QWRpRiL9xT7uV+CL",
+	"+okiwNmaKO9Hl9bYhILpZDj5nCZ4U++ZVX3oQ77bMA9ZlCLXS5xIAtEHA3d2oDT8pwcw9QkoTYMGmCFO",
+	"HnbVSyhlJhFJsmxtpge1s4bxzXgsrK0LKH6aP6EnTXSu0JK8ALpfLnCA/wGpnPBNbyZmJZEBJxnDM3x3",
+	"M7m5xYEdC6zXsD1UvYDdtcFl5dYIBP4Eel5bdbrH7WRyklp7Kci82dDbQtJX989/uquZUAPg5zYs9YLN",
+	"2WWvirfGm7A32xQ9Dqb7VyrtwkabtQ0nT1MiNzuEiCAO/zZHmSJoRifcNmbWwrijkICrivaOP9jrzR03",
+	"R+Vvwzhrk3DvKF08D8f+8L67rb29eQe2O8MdTcPxNzX+8GrztsnFJ9BIZRCxmEU1H2i1QcxqUkZ0tO7z",
+	"4tRxNGquXywXJ81HO7oJiTIiNSPmR7Qm/KWTR6aAXMM1EnJQ3xYNs9cQuOHufg2la6zYi95V3zya0Iti",
+	"REl0IUTaeWrHNNzWE5WHKLbI6VTJ0Mt6l8szXpiH2BpRR/kAXSWEwwWwM+oR03mt1ERqJGJkJiwUG0uk",
+	"BfqRg9ygWEj0y+PH+d3d3e+/4sBxam/VpCqzwEE+KcQkT8wodzu5vX03mb6bTL9MJzP7dzOZTv7Ggde4",
+	"VwRd9H9wegl24NQf+W+XIH9+TRXy1p5ut0qYsrlQp9gxdao8ntFZugc7Y0pOfdbTLKBwWx/f+ahNvdnT",
+	"OvK+I8VRB7Dm2dUxlRh9R6Of2B0evnZnZn6z10i0XL0+Rh28fGombJw3HMuxr6Xpm0m1kyS1Opc9U1hL",
+	"noy2kn5a+qpsCeJNZGX7GHxE7XbUmb4+yNzx5Ay31WeSEzT+2lQH3o8Of/8ZtVXsaC25jqVI9+WpX5m/",
+	"feJe6avNoBqcxrhXq3qbtI+kLRdnvnNwUhyMztjT+oPNbuksXrMz1V8FfE8b8gHsy7yJ/bxThuvAHiHc",
+	"rX5SveO4YN5Yl/8HAAD//7iWRZCMIAAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/api/api.gen.go
+++ b/pkg/api/api.gen.go
@@ -28,28 +28,28 @@ type Component struct {
 	// DisplayName Short and describing name.
 	DisplayName *DisplayName `json:"displayName,omitempty"`
 
-	// Id Identfication for objects. UUID prefered.
+	// Id Identification for objects. UUID preferred.
 	Id *Id `json:"id,omitempty"`
 
 	// Labels Labels are free text key value pairs for components.
 	Labels *Labels `json:"labels,omitempty"`
 }
 
-// Date Point in time. Nullable for open ends.
+// Date Point in time. Nullable for open end timeframes.
 type Date = time.Time
 
-// Description A longer text for detailed informations.
+// Description A longer text with detailed information.
 type Description = string
 
 // DisplayName Short and describing name.
 type DisplayName = string
 
-// Id Identfication for objects. UUID prefered.
+// Id Identification for objects. UUID preferred.
 type Id = string
 
 // Impact An impact connects a component and an incident with an impact type.
 type Impact struct {
-	// Reference Identfication for objects. UUID prefered.
+	// Reference Identification for objects. UUID preferred.
 	Reference *Id         `json:"reference,omitempty"`
 	Type      *ImpactType `json:"type,omitempty"`
 }
@@ -60,13 +60,13 @@ type ImpactList = []Impact
 
 // ImpactType defines model for ImpactType.
 type ImpactType struct {
-	// Description A longer text for detailed informations.
+	// Description A longer text with detailed information.
 	Description *Description `json:"description,omitempty"`
 
 	// DisplayName Short and describing name.
 	DisplayName *DisplayName `json:"displayName,omitempty"`
 
-	// Id Identfication for objects. UUID prefered.
+	// Id Identification for objects. UUID preferred.
 	Id *Id `json:"id,omitempty"`
 }
 
@@ -76,19 +76,19 @@ type Incident struct {
 	// In case of an incident the IDs refer to a component and vice versa.
 	Affects *ImpactList `json:"affects,omitempty"`
 
-	// BeganAt Point in time. Nullable for open ends.
+	// BeganAt Point in time. Nullable for open end timeframes.
 	BeganAt *Date `json:"beganAt"`
 
-	// Description A longer text for detailed informations.
+	// Description A longer text with detailed information.
 	Description *Description `json:"description,omitempty"`
 
 	// DisplayName Short and describing name.
 	DisplayName *DisplayName `json:"displayName,omitempty"`
 
-	// EndedAt Point in time. Nullable for open ends.
+	// EndedAt Point in time. Nullable for open end timeframes.
 	EndedAt *Date `json:"endedAt"`
 
-	// Id Identfication for objects. UUID prefered.
+	// Id Identification for objects. UUID preferred.
 	Id *Id `json:"id,omitempty"`
 
 	// Phase To reference a phase, its generation and order is needed.
@@ -102,10 +102,10 @@ type Incident struct {
 // It's identified by the incident ID and its own order.
 // Updates happen in a given order.
 type IncidentUpdate struct {
-	// CreatedAt Point in time. Nullable for open ends.
+	// CreatedAt Point in time. Nullable for open end timeframes.
 	CreatedAt *Date `json:"createdAt"`
 
-	// Description A longer text for detailed informations.
+	// Description A longer text with detailed information.
 	Description *Description `json:"description,omitempty"`
 
 	// DisplayName Short and describing name.
@@ -145,19 +145,19 @@ type PhaseReference struct {
 	Order *Incremental `json:"order,omitempty"`
 }
 
-// ComponentIdPathParameter Identfication for objects. UUID prefered.
+// ComponentIdPathParameter Identification for objects. UUID preferred.
 type ComponentIdPathParameter = Id
 
-// ImpactTypeIdPathParameter Identfication for objects. UUID prefered.
+// ImpactTypeIdPathParameter Identification for objects. UUID preferred.
 type ImpactTypeIdPathParameter = Id
 
-// IncidentIdPathParameter Identfication for objects. UUID prefered.
+// IncidentIdPathParameter Identification for objects. UUID preferred.
 type IncidentIdPathParameter = Id
 
 // IncidentUpdateIdPathParameter Positive and incrementing number for ordering and identfication of e.g. sub resources.
 type IncidentUpdateIdPathParameter = Incremental
 
-// IdResponse Identfication for objects. UUID prefered.
+// IdResponse Identification for objects. UUID preferred.
 type IdResponse = Id
 
 // IncrementalResponse Positive and incrementing number for ordering and identfication of e.g. sub resources.
@@ -697,38 +697,38 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/9Ra32/bvBX9VwhuwL4PUG0n2cv81i/ZBmNFayTty9o80OKVzU6mVJJKZhj+34dLShZl",
-	"SZb8Q2kH9KGxKPLcy3PP4Q9taZis00SCNJpOtzRliq3BgLJ/3RfPZnzOzGpePMRnHHSoRGpEIum0bElm",
-	"D0RoouBHJhRwIiRJmVmNaEAFNsQ/aEAlWwOdloPPOA1o8RKdGpVBQHW4gjXDwf6sIKJT+qdxiXbsnurx",
-	"jNPdLqCzdcpC83mTQidY15SYTQqnwRXeGBfjlaHgfVJbNDwR6r77awH9knJmoD/czLYngpPfhFSwBmlY",
-	"/PsJIWT5gOcHIMNiXLrDULAb0OaPhAuoEvzRPcHfwkQakPa/LE1jETKMbPxdY3jbnkPvO3YDV1P0BJIT",
-	"RvavjWiFv9fGUvbcDkYSURaFw5PP49XR5P0exZK3qQBx/BsKjuu9D6ic2CPqGKXTRGrHphl/zP+8Hjze",
-	"BOk9yZlMFJhMSY34Zg9FugrSXx/NYUH1gVW+Y/E9ZWEIWp+FDclJp3SRJDEweRzCimmi3VhRFscbojLp",
-	"5iyPplL/1vtUkoIyuTSwKILQAP9j06++PghtMD4udBqzzUerYcdffPCa7gIqeB82BDRmC4h1V9sPrlUh",
-	"e049v+Igz0GRyGTxHUKL+gHJX9PyeSKkQZU2Yg0j8jGLY7aIgUSJIkkKkoDkGtU7StSaGTqlWBnvsDXK",
-	"eN68EO18UG2UkEs7qD/YtjaTcSKXoIiB/xo7IgfDRGxtw40nEmlHr3dcnYODel4lyhAmOXG/L4RcErSc",
-	"xq5mvMHiUAainKYuGTaRekS+fJk9kFRBBAr4yDoX459kvGlNgmNPQ/x7SQ4TKbF33zIsfl+UXoVZ1WQ8",
-	"OOC0wyVD6Ec0h/UEc2kgllccTVMstCFJlKPWNpd+lIkqveCbnEkSMg34gh+6WeEyDpcVEdIlqeXpRYRA",
-	"XkBpNvomca1hYK37BVamgTKl2Kbq1HXV4FVKH61+r+kb6EY/Hdi7c4se6tPEcAFLJt+bzoCs9QY/JXsg",
-	"OfD+EPuKdLpiuhPKHBs97otyF+RrXn2aEZ80s/lCp0lvihU7Ko3OFkSBTjIVgq0pWalE8xdN7B8iEsDJ",
-	"YmOrUHhbFSw8YTRJXiVJFAc1+ibd2JqsWIruISRhZCleoGxRk6xQATOnTNDP4JBFf8mcuQ4CL9qWKdz3",
-	"0ODVWhjxAi7xRUvrbdl6Acr5FI6Dv9lGFRtLIgKj5agy8drNSIuHCWlgCQqRfdgvSRjnAvtj8bwyjzXf",
-	"q6J3HRCmgEQKwJn+f2BDXlicAUmZUM4dysR6dl2maF6U3aHTaCGXMRBblsjw75k2lp/W+ZHRJGSSLIDs",
-	"TdLSGpssQYJyWcK8FVx9ApiSLnrYBNaCtzCbTdE+KmfApoTFr2yDZSM5rn8YFihaZ93hS6gn0THXK9tF",
-	"L3d0ea6Z4wGtPTT7EZ7bZu3RX5xUc/I5KWeFMDeJQevU4PRKAO4WYAf+fHaNn53Zq4mDh6CeRHwJ18W2",
-	"1oTBVTd9un8iT4aZTJM5WwJ5P5/RgOJCyKX1ZjSxAFOQLBV0Su9Gk9Et5oyZlU3XuHo6uARLWEyoxYGL",
-	"Y/pPMPdlq4Mt8e1kctIOrxf5vMOVGgFryvLpX27Tl63XTG0c3rx8UPN8PcEySHRDiPdWlsth/ZOk1u1h",
-	"5bBpXDtp2tUyddPeU95u7J0wVINyCAkjEl4rB0u7wJ/E8dY7cd25QovBLQeqIT/Y3/2Q/aPhr81Ayybj",
-	"1qPj3XMzRY4HfnhqUI3ega0dqXXS9WdH1TqdjqM6hVBEIvS2M+hI3DGVmXBVD88tsQaL8Pqsv3jyXcQH",
-	"k4+0d5tK1Iej4lVu595Gvfwd88Xy5W33uwXMG/mMuawfUA8oYdXT6IPZHG/9i5geMlYJ/LR6aL9WGlLI",
-	"6sfx3ex9g9De4Dqihe97KfTy0lcMB0zRACV0PT1syllRTPlG/bgw7hvV0nZwomqYsmpkxBr3b2xtjwx+",
-	"ZKA2dtP22+M/7u/u7v72+/6mzz4rr/o09nD0no9DxLLY0Cm9ndzevpvcvJvcfL6ZTO2/0eRm8u+2Y+iD",
-	"zdcuOIT/d9w4XAAeJO8P/a+XQH9+E3/aX9Bd7k4Fg8gCzCuAJOY1IWki8KfiWqHTtQo85xTcwSXmkI5V",
-	"3llWKmy8La/i+1hVGe2JUtXyPcHANuXf1HYJyeAxDX5B3elOxQFoX2saJjNXr5KrmZLsVydj7xy8i1X5",
-	"ofKvQ66TVLb47uBirc0zRiKVrJso2Vtnc0S/BCOr33wMqN751Ye9PGxKXTdVx9vie6UTVP7auQ56v9r8",
-	"NdeghzP7vObJbmNqHyv5f0ncG32j1OVLHRnvb1S/Zt4HUpcBtmLdE4FKU17GtNVBeYFUm4qmLUrlIuac",
-	"b72GpHcZS19mmxWQMFMKV1reDVBhhS59nYbn5/CAQ9eP6zzvaviW74iJeanA/eyquO50V4UI4n8BAAD/",
-	"/2mROTrvLQAA",
+	"H4sIAAAAAAAC/9RaW4/buBX+KwRboLuAYnsmfanfsjNtYTTYNWaSl27yQIvHNlOZ0pLUTA3D/704pC7U",
+	"zZIvmqRAHjIWRX7n9n3koQ40jHdJLEEaTecHmjDFdmBA2b8e8mcLvmRmu8wf4jMOOlQiMSKWdF6OJItH",
+	"IjRR8EcqFHAiJEmY2U5oQAUOxD9oQCXbAZ2Xiy84DWj+Ep0blUJAdbiFHcPF/qxgTef0T9MS7dQ91dMF",
+	"p8djQBe7hIXm0z6BXrBuKDH7BM6DK7w1rsYrQ8GHuDYfeCbUYvpbAf2ccGZgONzUjieCk5+EVLADaVj0",
+	"8xkmpNmClxsgw3xdekRTcBrQ5peYC6gm+JN7gr+FsTQg7X9ZkkQiZGjZ9JtG8w4Dly4mdgtXXfQMkhNG",
+	"itcmtJK/t8ZSztwNRhJRFoXDk8Xx5miyeU9iycZUgLj8GwuOm30IqCyxJ9RllE5iqV02LfhT9uft4PE2",
+	"SB9IlslEgUmV1Ihv8Zi7K0/626OpF9QQWOU7Ft9zGoag9UXYMDnpnK7iOAImT0PYMk20W2udRtGeqFS6",
+	"mGXWVOrfap+KE1Amowa2XkNogP+yH1ZfH4U2aB8XOonY/lfLYadffPSGHgMq+JBsCGjEVhDpvrEf3aic",
+	"9hx7/o6LfA1yR8arbxBa1I+Y/A0uX8ZCGmRpI3YwIb+mUcRWEZB1rEicgCRYGvhsjXKgkcfXsdoxQ+cU",
+	"a+QdPkNCz17M6TtbXhsl5MYu7y97aMQ0iuUGFDHwX0NehdkSDoaJyCqIW1DEEldvTlyNRq2yt7EyhElO",
+	"3O8rITcExad1qgVvETskBLHOMtb5xfpUT8jnz4tHkihYg1LAJ1bFGP9NRvtON7hMavFAQc9hLCVO78uH",
+	"tcAnKOuiOqUHtfy2wECGMCzpHNYzhKYlybxCaQuy0IbE6wy1ts70rYxVqQtf5EKSkGnAF3zTzRa3dLjF",
+	"WGPCxA0/vYgQyAsozSZfJO47DOz0MMNKN1CmFNtXVbvJILya1CeZwBv6BhwyjBMKpe7gRn0eMa5gw+QH",
+	"02uQleHgu3gPJAc+HOJQwk62TPdCWeKgp6Ioj0G2/9XnifJZkc02PW18k+/ekWl0uiIKdJyqEGxNyUol",
+	"mr9oIjIiBE5We1uFwju2YOEJo0n8KkmsOKjJF+nW1mTLElQSIQkjG/EC5YgGZYUKmDknQN8jhyz6a2Lm",
+	"Jgg8aztCWMzQottaGPECzvH5SKtu6W4FygkVroO/2UEYqkLH4jWByWZSCbx2EenQMCENbEAhso/F9oRx",
+	"LnA+Fi0rcWzoXhW9m4AwBWStAJzs/wf25IVFKZCECeXUoXSsJ9ili5Z52dWVRgu5iYDYssQM/5ZqY/PT",
+	"aj9mNAmZJCsghUjatMYhG5CgnJfQb3muPgPMSV96WAc2jLcw20XRPiojYF3Cole2x7KRHDdADAsUpbOp",
+	"8CXUs9Ix4ys7xSB1dH5uiGMtrT00xQpfu6L25G9Oqj75FJdRIcwFMegMDYZXAnC3Aavp88U1frFnb0YO",
+	"HoKmE/El3BjbWhMG9930+eGZPBtmUk2WbAPkw3JBA4obIefWu8nMAkxAskTQOX0/mU3u0WfMbK27ptVO",
+	"4QZswqJDLQ7cHtN/gnkoR9WOx/ez2VmnvUHJ5zVaGgnYYJbf/uUOgOlux9Te4c3KBznP5xMsg1i3mPhg",
+	"ablc1u8qdR4VK42naaPrdGx46q57pmzc1Os2VI1yCAkjEl4rTaZj4AdxevC6r0dXaBG47UDV5Ef7u2+y",
+	"3yb+vR1oOWTa2UY+fm1PkdOG1zsIVesd2EZ7rTddv7dVneF0OaoTCPGg6R1nUJG4y1Rmwm3TPLfFGs3C",
+	"22f91cF3FteCj2nvDpXIDyfJqzzOvQ17+Sfmq+nLO+73E5i38gWxbDarR6Swame6Fs3pwb+UGUBjFcPP",
+	"q4fuK6YxiazZmu/P3jcw7Q2uJjryvaBCzy9DyXBEF41QQrfjwzaf5cWUHdRPE2MxqOG2Wk/VMGXZyIgd",
+	"nt/YzrYM/khB7e2h7aenfzy8f//+bz8Xt372WXntp3GGk3d+HNYsjQyd0/vZ/f272d272d2nu9nc/pvM",
+	"7mb/7mpE1w5fx6AO/+94cLgCPEg+HPpfr4H+9U30qbisu16d8gwiKzCvAJKY15gkscCf8iuGXtXK8VxS",
+	"cLULzTEVq7y/rFTY9FBeyw+RqtLaM6mq49uCkWXKv7XtI5LRbRr9srpXnfIG6FBpGsczN6+Sm4mSHFYn",
+	"U68P3pdVWVP5x0mus1g2/wbhaq7NPEbWKt61peRgns0Q/RAZWf3+Y0T2zq4+7OVhm+v6U3V6yL9dOoPl",
+	"b+3rYPCr7V92jdqcKfyaObsrU4dIyf+L497oe6U+Xerx+HCh+jH9PhK7jHAU6w8EMk15GdNVB+UFUiMU",
+	"bUeUykXMJd99jZnepS1DM9tsgYSpUrjT8m6Acil07usVPN+HtRy6vV2XaVfLd30nRMxzBZ5nt/l1p7sq",
+	"RBD/CwAA///OXjTp+y0AAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/api/api.gen.go
+++ b/pkg/api/api.gen.go
@@ -166,6 +166,9 @@ type Success = bool
 // ComponentIdPathParameter Identification for objects. UUID preferred.
 type ComponentIdPathParameter = Id
 
+// GenerationQueryParameter Positive and incrementing number for ordering and identfication of e.g. sub resources.
+type GenerationQueryParameter = Incremental
+
 // ImpactTypeIdPathParameter Identification for objects. UUID preferred.
 type ImpactTypeIdPathParameter = Id
 
@@ -256,6 +259,9 @@ type IncidentRequest = Incident
 // Updates happen in a given order.
 type IncidentUpdateRequest = IncidentUpdate
 
+// PhaseListRequest Phase resources are always handled as a list.
+type PhaseListRequest = PhaseList
+
 // GetIncidentsParams defines parameters for GetIncidents.
 type GetIncidentsParams struct {
 	// Start Start of time frame to query for (RFC3339).
@@ -267,7 +273,8 @@ type GetIncidentsParams struct {
 
 // GetPhaseListParams defines parameters for GetPhaseList.
 type GetPhaseListParams struct {
-	Generation *Incremental `form:"generation,omitempty" json:"generation,omitempty"`
+	// Generation Optional generation in query. E.g. ?generation=7
+	Generation *GenerationQueryParameter `form:"generation,omitempty" json:"generation,omitempty"`
 }
 
 // CreateComponentJSONRequestBody defines body for CreateComponent for application/json ContentType.
@@ -773,41 +780,42 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/9xbS48buRH+KwUmQHaBtqQZ5xLdvDNJIGCwEWbsS9Y+UN3VEp0Wu02yZyII+u8ByX6w",
-	"XxL1HCPAHtYSxXp9/KqKxdmSMF1nKUeuJJluSUYFXaNCYf71UH43i+ZUrebll/q7CGUoWKZYysm0Xgmz",
-	"R2ASBP7ImcAIGIeMqtWIBITphfofJCCcrpFMa+GziASk/BGZKpFjQGS4wjXVwv4sMCZT8qdxre3YfivH",
-	"s4jsdgGZrTMaqs+bDA8qa5eC2mR4nLrMkXG2vjxkkY9ry4VHqlptfylFv2QRVeivbm7WA4vgF8YFrpEr",
-	"mvx6hAl5IfB0A3hYyiU7bYreBqX6LY0YNgH+bL/Rn4UpV8jN/9IsS1hItWXj71Kbt/UUXW1sBTdd9II8",
-	"AgrVz0akgd9L61LvPKwMB1YfCqtPEceLa1Psu1eXYk1DEYu/a6ljd/dRqgD2iFhEySzlsoWmJybVc/HN",
-	"UZpmIs1QqAKdEVX+QNMyjUo6gmRK0sV3DHu9/AmKcwACVS64BAoJkwrSuMakNL53zsdtrTndktapim6k",
-	"eUGWp6jMYfbYooAbAqgp9HwEOTwiO8R2Y4vOCMkQHd4yMo7IC8Sl2E222P2mppwTkOGc8A4xqQVfLjJF",
-	"YpG9We8drLtAsOpcaSwqq7HbmePUfyeTc72LsWO+ovKWkKvknY60TG9h8GYseMnDEKW8kf6FtGO1X1EJ",
-	"0v40zpNkAyLntuYqNm5UXF3VaBxjqDD6beOXL6yHAxIxmSV087vpQfb/8NFZugsIi3yKhIAkdIGJPLT2",
-	"ya4q2xbb/fyhhXzr+DFolp56a6ZwLY8ot7QUGv2LJ5uyxypkUCHoRn//qCmh0+7NU8aVbuQUW+MIfs+T",
-	"hC4ShDgVkGbIQVfP+rtYd4xSt3pxKtZUkalGD37Q3+mer/hhS7pUgvGlEe+K3XZgk6R8iQIU/lfBG1Mr",
-	"iFBRlpgm0wpkKdfSuxs3A94q/lepUEB5BPbzBeNL0P1p71azqKcf1jzI4uJEWb+YsMkRfPkye4RMYIxC",
-	"YDQig0FwRBiw9nigKlnClHO9vVsLGwtcXjYuapc5QesIGcWQh+iHa6vrObVZaV4J4k6QGzWmNM50rUxF",
-	"XSZ85TMOoea9NG6YrlYIs0cJxjpQacdPryxEeEUh6egrJ4HfUSrisuueG8fkLn82Qb2XbJylN6ApP9pp",
-	"NQ++vOOi4DDxVMXjAMfL4wh+gUvKP6mDXjMVUPAuIUIeYeSvom/iMWWAV7nxXJ38XVDcw8kjqq2qWvGB",
-	"kNvleAOo6if84VMUtX3MWV5Vas6U+QIEyjQXIRp24A1OUX+RwApKxwgWG8MnzLmj1RTClIT0jUMqIhSj",
-	"r9zKlrCimc6JjAOFJXvFekWHfEOBVB2DgvcAqtH+2DLcBYXdIHCs3YcRp+s6FillS+OFl0rdnnJHMsVe",
-	"0Ua5XGmKgny9QGHzuzZKf2YWaelV+k9jwNFy1ECZtOEf0ItxhUsULc36M+RTkR+dhTZJlplcKyXzRS3Z",
-	"O725MTzsw6eqxKVRxLR2NJk34N0pbFqWmA2ACoRYINq67j+4gVea5AgZZcJa5l5Y9iBnXlJeu5SQjC8T",
-	"LDojJuF7LpU5tqa40wcdQsphgZXv7GnXS5bIUdh46giXR/gFcQoenGqi3bG/bvO6oDNKVkEzXqHJG91o",
-	"QuGRLnJpeaHQreJqbY8MsvGN9D5p1tWdAqh14B1tKgnfhgL37BagTZ98TuvAlB1uMBgdHWGOGNkiu1WD",
-	"ncx+J3v2YrTpaNDnxLL17st52gXWS2+NTts5Ros0TZBy26frNsocXKZ0l0ZeHl7gRVGVS5jTJcKn+YwE",
-	"RJfNVsTdaGJMzZDTjJEp+TiajO6196laGZXGzdHzEg30K710M0X+ieqhXtWat9xPJkNOrNaN+4cy5h4h",
-	"X6+p2FgpwzOQLJU9ij2YhFU30O5wcTOslTN/HHeGj7uOfXeH7XMmHE2jrIZAgeNbYyqyC1zXj7fOEH5n",
-	"oZKgLZSaJj+az12T3dcCf/QrWi8ZD74m2H07JbDtW6ym9VbZzjzoIMje26ruxK0PqjLDkMUsdDpXnZsi",
-	"C1iqwlXXSlsBXc3Qy4P/bAxYi1sY0Oi39wdmRLWPeeo29TTqGZjn7eOezvRsH/s4bfQJEeg+OLgi/zTH",
-	"aa0YjLfuwxoPDmoYfhyKh58JXZOFuvPEw5h7d9N6Brd7ucgx0ZeNrmjtFU7D5Qipz2fluSjntHuZqVrU",
-	"cVvr/lpRYYhFsbVupejaXGr8yFFsTP/0y/M/Hj5+/Pi3X6tHWOa7+hWW1DvsfYIVYUzzRJEpuZ/c33+Y",
-	"3H2Y3H2+m0zNf6PJ3eTfQ5f+rSZoF7TV/7su4M9QHnnkr/pfz1H9tBPW96hgb3oo4w4LVG+IHNRbClnK",
-	"9EflEOZg2igvz045Jq1XYddMGfXAv3Euxtv6baNPrqitPZJgBh5oXjlPuM8cDh3/d7ap84hkf3oo70h9",
-	"c8N1jLw44C+WFbgf5MfOffwhgBT3zj8JTnpe6+wju8JOiEW67gOSN9EVd78/BY6ar1hPo8+ehzR7eLQY",
-	"bphBZ58PDyNtvC2fYh/Bt5d2euD90/6H6le9ZKj8Wjh7CLI+pP7/4biB92t7M8QB5/mnjJ/ThVdijCt0",
-	"JYcDoUmjng8MQbqeaXRC0VetN2YDp/yJx0lI7b7n64JUrRDCXAhdvjjzhTJTWU8czEeuO1pwuMjfMrgv",
-	"BXe3SC2OK3SXtsLmS8Pdbve/AAAA//8S4DNZYDYAAA==",
+	"H4sIAAAAAAAC/9xb62/cuBH/VwZsgd4BinbtFCi6QFHk7OthgeDOjZMvveQDVxrtMtVSCknZXRj7vxck",
+	"9aCeK+3LwQH+YEsUOY8ffzPDoV9IkGzThCNXkixeSEoF3aJCYf66K94twweqNg/FS/0uRBkIliqWcLKo",
+	"RsLyHpgEgd8yJjAExiGlauMTjzA9UP9BPMLpFsmiWnwZEo8UH5GFEhl6RAYb3FK92J8FRmRB/jSrpJ3Z",
+	"t3K2DMl+75FfkKOgWpx/Zyh2A7L+Zn6hMazLT7SY3/RnPvzsr334Z/XqH38rRDcDKtmrIWS0qDwQuEWu",
+	"aGxkXm5TGqiPuxQPGtgOBbVLcZqJmbPGqTZe8oCFY+BQDJwoajn9uQT9lIZU4XhxMzMeWAg/MF646scJ",
+	"KmT5gscrUIPI3k6DUv2UhAzrm/KDfaOfBQlXyM2vNE1jFhhczr5Krd7LyKXLie3CdRM9Ig+BQvmZT2r4",
+	"Pbcs1cz9wnBg1aaw8uR+PLs0+byDsuRjaoJY/F1KHDv7GKFyYBvZHjZU4nsmz26lcuIB/HB8hphJBUkE",
+	"qR4vfWJRLtOEywbCrZT2zSQxU5GkKFS+Y0KqxoM/V8AjGlVkQZLVVww6VXoH+d4EgSoTXAItdatWMDZ3",
+	"9ux1tTlek8ZOD68keU7gx4jMYXnfoKUrAqi+6OkIcrhNtsj2yhqd4JI+ir6mZ5wlz+CXfDbZiDhXVeUU",
+	"h/THqVfwSbXw+TyTBzvZGYlfQbszOMuN306GeD11amXLkeRczdLMQ66ihZueHIk0k7EYvBkNHrMgQCmv",
+	"JH++2lTpN1SCtJ9GWRzvQGTc5lz5xLWMqy0ajSIMFIY/7cbFC2thj4RMpjHd/WrqouEP752he4+wcEyS",
+	"4JGYrjCWh8a+t6OKUspWZL/rRb607OjVU089NVO4lRPSLb0KDX/j8a6o+/I1qBB0p9/fa0polaAPCeNK",
+	"F5eKbdGHX7M4pqsYIUoEJCly0PmzfhfpKlbq8jNKxJYqstDowTf6na5D8w8bq0slGF+b5d1lX1qwiRO+",
+	"RgEK/6fgmakNhKgoi03haxdkCdertyeuO7yR/m8SoYDyEOzzFeNr0DVz51TLsKNG1zzIonxHWbsYt0kf",
+	"Pn1a3kMqMEIhMPRJrxOcJQxYOyxQpixBwrme3s2FjQYuLxsTNdMcr7GFjGDIAxyHayvrKblZoV4B4paT",
+	"azmmNMZ0tUxElSZ85ksOgea9JKqprjYIy3sJRjtQSctOTyxAeEIhqf+ZE2/cVsr9sm/vG0flNn/WQT1I",
+	"Ns7QK9DUONppFA9jecdFwWHiKZPHHo6X0wh+hWvK36mDVjMZkPcqLkIeYjhexLGBx6QBo9KND+XO33v5",
+	"2aCckG2V2coYCLlVzmgAlfXEePjkSW0XcxbHp5ozZbYCgTLJRICGHXiNU9RfJLCc0jGE1c7wCXPOjTWF",
+	"MCUheeaQiBCF/5nbtSVsaKpjIuNAYc2esBrRIt9AIFVTUPAaQDXST03DXVDYCTxH2yGMOFXXVKQUJc0o",
+	"vJTidqQ7kin2hNbLxUiTFGTbFQob37VS+pkZpFcvw38SAfprv4Yyad3fIxfjCtcoGpJ1R8j3eXx0Btog",
+	"WURyLZTMVtXKo8Ob68PDNnxfprg0DJltWz3U4N1KbBqamAmACoRIINq87r+4gycaZwgpZcJq5h5YdiDn",
+	"oaC8ZiohGV/HmFdGTMLXTCqzbU1ypzc6BJTDCkvb2d2uhzj9N+3hYgs/Ii5gBKcab7f0r8q8NuiMkKXT",
+	"jFVo/Ex3mlB4qJNcWhwotLM4p983zcn2nHv0TrOmbiVAjQ1f6z7mK3zpc9wHNwGt2+RjUjmmqHC9Xu9o",
+	"D3PE0CbZjRzsaPY72rJno01Hgi4jFqV3V8zTJrBWeq5V2s42WiVJjJTbOl2XUWbjMqWrNPJ49wiPiqpM",
+	"wgNdI7x7WBKP6LTZLnHjz42qKXKaMrIgb/25f6utT9XGiDSrt/DXaKBfyqWLKfILqrtqVKPfcjuf9xmx",
+	"HDfrbsqYc4Rsu6ViZ1fp74GkiewQ7M4ErKqAdhueu36pnJ7orNUQ3bf0uzmsn9PhqCtlJcx7V25XZO+5",
+	"pp+9OJcZ9hYqMdpEqa7yvXnuquzeuvi9W9BqyKz3Vsb+yzGObZ5i1bW3wrb6QQdB9tpatTtuXVCVKQYs",
+	"YoFTuerYFFrAUhVs2lraDOhiip4f/CdjwGrcwIBGvz0/MC2qIeapytTjqKennzfEPa3u2RD7OGX0ER5o",
+	"X4K4IP/U22kNH8xe3Ms+Iziopvg0FPdfXbokC7X7iYcx9+qqdTRuB7nIUXEsG11Q2wvshvMRUpfNin1R",
+	"9GkHmakc1DJb4/xaUWGIRbGtLqXo1hxqmCuBpn764cO/7t6+ffv3H/2e64JSzzB4LSzEiGaxIgtyO7+9",
+	"fTO/eTO/+XgzX5gff34z/0/foX+jCNp7TfF/1gn8CcIjD8eL/tdTRD9uh3VdKhgMD4XfYYXqGZGDek4g",
+	"TZh+VDRhDoaN4vDsmG3SuKl2yZBRNfxr+2L2Ut23HBMrKm0nEkzPpdELxwn3msOh7f/KOrUukQyHh+KM",
+	"dGxsuIySZwf82aICHwf5mXMefwgg+bnzd4KTjts6Q2SX6wmRSLZdQBpNdPnZ73eBo/rN2uPos+MizQCP",
+	"5s0N0+jssuFhpM1eiuvhE/j23Eb3Rn/afXn+oocMpV1zY/dBdgyp/zEM13N/bTBCHDDe+JDxfZrwQoxx",
+	"garksCM0aVT9gT5IVz2Nqa7o/a+o49DYvrPXBqLaIASZEDpFcXoIrVv/wzHHVXmyy1v/4nCN+ODoqkut",
+	"DdavC+73+/8HAAD//9tb8WttNwAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/api/api.gen.go
+++ b/pkg/api/api.gen.go
@@ -36,6 +36,9 @@ type Component struct {
 	Labels *Labels `json:"labels,omitempty"`
 }
 
+// ComponentList defines model for ComponentList.
+type ComponentList = []Component
+
 // Date Point in time. Nullable for open end timeframes.
 type Date = time.Time
 
@@ -71,6 +74,9 @@ type ImpactType struct {
 	Id *Id `json:"id,omitempty"`
 }
 
+// ImpactTypeList defines model for ImpactTypeList.
+type ImpactTypeList = []ImpactType
+
 // Incident defines model for Incident.
 type Incident struct {
 	// Affects A list of impacts for a component or incident.
@@ -95,9 +101,12 @@ type Incident struct {
 	// Phase To reference a phase, its generation and order is needed.
 	Phase *PhaseReference `json:"phase,omitempty"`
 
-	// Updates An incident will have multiple references to updates and they should not be changed.
-	Updates *[]Incremental `json:"updates,omitempty"`
+	// Updates List of Incrementals for referencing subresources.
+	Updates *IncrementalList `json:"updates,omitempty"`
 }
+
+// IncidentList defines model for IncidentList.
+type IncidentList = []Incident
 
 // IncidentUpdate An update is a sub resource to an incident.
 // It's identified by the incident ID and its own order.
@@ -116,8 +125,14 @@ type IncidentUpdate struct {
 	Order *Incremental `json:"order,omitempty"`
 }
 
+// IncidentUpdateList defines model for IncidentUpdateList.
+type IncidentUpdateList = []IncidentUpdate
+
 // Incremental Positive and incrementing number for ordering and identfication of e.g. sub resources.
 type Incremental = int
+
+// IncrementalList List of Incrementals for referencing subresources.
+type IncrementalList = []Incremental
 
 // Labels Labels are free text key value pairs for components.
 type Labels map[string]string
@@ -299,6 +314,240 @@ func (t *ResponseData_Content) FromIncremental(v Incremental) error {
 
 // MergeIncremental performs a merge with any union data inside the ResponseData_Content, using the provided Incremental
 func (t *ResponseData_Content) MergeIncremental(v Incremental) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JsonMerge(b, t.union)
+	t.union = merged
+	return err
+}
+
+// AsPhaseList returns the union data inside the ResponseData_Content as a PhaseList
+func (t ResponseData_Content) AsPhaseList() (PhaseList, error) {
+	var body PhaseList
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPhaseList overwrites any union data inside the ResponseData_Content as the provided PhaseList
+func (t *ResponseData_Content) FromPhaseList(v PhaseList) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePhaseList performs a merge with any union data inside the ResponseData_Content, using the provided PhaseList
+func (t *ResponseData_Content) MergePhaseList(v PhaseList) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JsonMerge(b, t.union)
+	t.union = merged
+	return err
+}
+
+// AsImpactType returns the union data inside the ResponseData_Content as a ImpactType
+func (t ResponseData_Content) AsImpactType() (ImpactType, error) {
+	var body ImpactType
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromImpactType overwrites any union data inside the ResponseData_Content as the provided ImpactType
+func (t *ResponseData_Content) FromImpactType(v ImpactType) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeImpactType performs a merge with any union data inside the ResponseData_Content, using the provided ImpactType
+func (t *ResponseData_Content) MergeImpactType(v ImpactType) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JsonMerge(b, t.union)
+	t.union = merged
+	return err
+}
+
+// AsImpactTypeList returns the union data inside the ResponseData_Content as a ImpactTypeList
+func (t ResponseData_Content) AsImpactTypeList() (ImpactTypeList, error) {
+	var body ImpactTypeList
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromImpactTypeList overwrites any union data inside the ResponseData_Content as the provided ImpactTypeList
+func (t *ResponseData_Content) FromImpactTypeList(v ImpactTypeList) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeImpactTypeList performs a merge with any union data inside the ResponseData_Content, using the provided ImpactTypeList
+func (t *ResponseData_Content) MergeImpactTypeList(v ImpactTypeList) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JsonMerge(b, t.union)
+	t.union = merged
+	return err
+}
+
+// AsComponent returns the union data inside the ResponseData_Content as a Component
+func (t ResponseData_Content) AsComponent() (Component, error) {
+	var body Component
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromComponent overwrites any union data inside the ResponseData_Content as the provided Component
+func (t *ResponseData_Content) FromComponent(v Component) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeComponent performs a merge with any union data inside the ResponseData_Content, using the provided Component
+func (t *ResponseData_Content) MergeComponent(v Component) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JsonMerge(b, t.union)
+	t.union = merged
+	return err
+}
+
+// AsComponentList returns the union data inside the ResponseData_Content as a ComponentList
+func (t ResponseData_Content) AsComponentList() (ComponentList, error) {
+	var body ComponentList
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromComponentList overwrites any union data inside the ResponseData_Content as the provided ComponentList
+func (t *ResponseData_Content) FromComponentList(v ComponentList) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeComponentList performs a merge with any union data inside the ResponseData_Content, using the provided ComponentList
+func (t *ResponseData_Content) MergeComponentList(v ComponentList) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JsonMerge(b, t.union)
+	t.union = merged
+	return err
+}
+
+// AsIncident returns the union data inside the ResponseData_Content as a Incident
+func (t ResponseData_Content) AsIncident() (Incident, error) {
+	var body Incident
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromIncident overwrites any union data inside the ResponseData_Content as the provided Incident
+func (t *ResponseData_Content) FromIncident(v Incident) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeIncident performs a merge with any union data inside the ResponseData_Content, using the provided Incident
+func (t *ResponseData_Content) MergeIncident(v Incident) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JsonMerge(b, t.union)
+	t.union = merged
+	return err
+}
+
+// AsIncidentList returns the union data inside the ResponseData_Content as a IncidentList
+func (t ResponseData_Content) AsIncidentList() (IncidentList, error) {
+	var body IncidentList
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromIncidentList overwrites any union data inside the ResponseData_Content as the provided IncidentList
+func (t *ResponseData_Content) FromIncidentList(v IncidentList) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeIncidentList performs a merge with any union data inside the ResponseData_Content, using the provided IncidentList
+func (t *ResponseData_Content) MergeIncidentList(v IncidentList) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JsonMerge(b, t.union)
+	t.union = merged
+	return err
+}
+
+// AsIncidentUpdate returns the union data inside the ResponseData_Content as a IncidentUpdate
+func (t ResponseData_Content) AsIncidentUpdate() (IncidentUpdate, error) {
+	var body IncidentUpdate
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromIncidentUpdate overwrites any union data inside the ResponseData_Content as the provided IncidentUpdate
+func (t *ResponseData_Content) FromIncidentUpdate(v IncidentUpdate) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeIncidentUpdate performs a merge with any union data inside the ResponseData_Content, using the provided IncidentUpdate
+func (t *ResponseData_Content) MergeIncidentUpdate(v IncidentUpdate) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JsonMerge(b, t.union)
+	t.union = merged
+	return err
+}
+
+// AsIncidentUpdateList returns the union data inside the ResponseData_Content as a IncidentUpdateList
+func (t ResponseData_Content) AsIncidentUpdateList() (IncidentUpdateList, error) {
+	var body IncidentUpdateList
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromIncidentUpdateList overwrites any union data inside the ResponseData_Content as the provided IncidentUpdateList
+func (t *ResponseData_Content) FromIncidentUpdateList(v IncidentUpdateList) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeIncidentUpdateList performs a merge with any union data inside the ResponseData_Content, using the provided IncidentUpdateList
+func (t *ResponseData_Content) MergeIncidentUpdateList(v IncidentUpdateList) error {
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -795,40 +1044,40 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/9Ra32/juBH+Vwi2QO8Ar+VkiwL1217SHowuboNkFwV6mwdaHFvck0gdSSU1Av/vxZD6",
-	"QVlSJCd2bgvsw8aiyJmP33xDzuiJxirLlQRpDV0+0ZxploEF7f66qp6t+A2zyU31EJ9xMLEWuRVK0mUz",
-	"kqyuiTBEw++F0MCJkCRnNpnTGRU4EP+gMypZBnTZLL7idEarl+jS6gJm1MQJZAwX+7OGDV3SP0WNtZF/",
-	"aqIVp/v9jK6ynMX28y6HUWP9UGJ3ORxnrgjWeLW9MhZ8CrTVwCNNrac/laFfcs4sTDe3cOOJ4OQHITVk",
-	"IC1LfzzChaJc8OUOyLhal+7RFZwGjP1JcQFtgt/6J/hbrKQF6f7L8jwVMUPPom8G3XuauHQ9sV+4DdEd",
-	"SE4YqV+b0xZ/T21LM/OwMZKIJii8PeU+ntyact5nbSnHtAzx/DuXOX72KUaVxJ5TzyiTK2k8m27LP05m",
-	"XDXhNbOsz7SfQYJmKamsIBuliSniGIzZFClROWi3rvHWlvO2mO9UX+NIWwYF22wgtsB/2k1j1kdhLG4U",
-	"FyZP2e4XF73Pv3gdDN3PqOBTtGhGU7aG1IyN/ehHVQHvdeNXXOR+RpHfdEnV+hvEzupr3PaOit0oIS3q",
-	"kxUZzMkvRZqydeoBVjlIgqTAZxsUQoMKtlE6Y5YuKbLjHT5DKStfrISrXN5YLeTWLR8ue2jFB5IquQVN",
-	"LPzXkkdhE8LBMpE67fQLCiVx9e7E7d044HSitCVMcuJ/Xwu5JSi7vVOteI/MYyiITclrj4vD1MzJly+r",
-	"a5Jr2IDWwOdOvxn/JNPdIAyeST0I1MIUKylx+lA4nQdhaDqIDsVsdsBvZxjIGKaRztt6hMT2kCwIlL5N",
-	"FsYStSmtNg7M0EulG0X8KleSxMwAvhC6bhM8zGBy3SBhVAenBxEDeQBt2PyrxIxrITPTHGtgoExrtmvn",
-	"q66C8Dapn1WCYOgbaMg0Tahz1IA2muOEcQ1bJj/YUYdcApr9IeiB5MCnmzhVsPOEmVFTbnDQbR2U+1l5",
-	"8jP9ctDEepqShD0AyYrUijwFUke2wQAoZ3HktwnsiElUkXIilSVrIHHC5NbL07RQCE+Tg5JWxsdxPCsP",
-	"H33uVqdo1D1TrDHVq0LH4CJctnTB/sUQUcoycLLeOU0QwfUBkRDWEPUoidIc9Pyr/FKilLAc85qQhJGt",
-	"eIBmREdAYw3MHkOXP4LRzvrjbgjtPfMTzAJvB7awnqHnFGGEFQ/gga9GulxbZGvQPm3iOvibG4RbVWdV",
-	"tSEw385bG2/8jgzQT0gLW9Bo2cf6sMQ4FzgfS29a+9jJwm3r/QSEaSAbDeAPIb/BjjywtACSM6F9rmqA",
-	"DY4PDUQ3lQgc5j0j5DYF4kQCGf6tMNbx051EkNEkZhJjtQ5sR2scsnVHX4cS4lZx9Q5gSSaojMOw478b",
-	"05+l3aNmExwqLH1kO4wcyfFExjBGMZd3jxyNtUeqjMPGTTFJozzU+xE1CqypV7gf2rjb8LTUxuSzajaG",
-	"ML+Ps8HdwR2WANxL7sGB4cVh/mJkT6YPgQV9ILbucB0I/61ZbpxOa7CFBE44s8ypsCwP1BWrE2tzs4yi",
-	"rbBJsZ7HKovu1ANoEFt5laqC31kW/xYZy2xh3uVsC+/wpsJyEQljCjDR3/q0vLmnKgmfNnT56/OQ3Pnr",
-	"Jd3PJhwAjkD3vvfgXK3Wlxrr2y15ZCa49gYitFYqBSb93RlvTE72hMULGb27uiN3Di1yw7ZAPtys6Izi",
-	"CdkvcTFfOKJ4EOmSvp8v5peIILOJMylqF0+34HGs7MJ7E/0Z7FUz6qBicLlYHFUsmCQCQe2pIwQdkf/0",
-	"L18ZKLKM6Z23t5QxTD+htKMcKdPj4pXLkM2yYaFtsIbQqsVFnULcvoPUxfBM5bi6XnLgkrePMCLhsVV1",
-	"28/CLYyegnL03lMuBX8uazt87X4PHQ7r5gMB1AyJBuvq+/t+grzIbW9lp9A4ytLv1B1PTJNDLDYiDi63",
-	"eCLgnp7MxknXOX/EPZt/p6f6y0Hyrh7sOdLc1xZQDZ6VquZW/zZaFRZOXi1WQdVnXK6ClV+wid1q/dkE",
-	"q12YP9jL6CnsSU0QrZbbx4XBcIftLLLVbUmMk/YNfHqDlswAzWvpC3CZKn5nhOgMkXMC/esDqwqfsiLy",
-	"vBDWgzp4HZTSLdNOfazI8KLMMleb+b0AvXO34x9u/3n1/v37v/9Ytznds6bPaXCGZ5ucHDasSC1d0svF",
-	"5eW7xcW7xcXni8XS/ZsvLhb/Geo/HFxx8UTeNv8feD17hfEg+XTT//oa0+/fJB/V3cnXZ6OKQWQN9hFA",
-	"EvuoSK4E/lR1lkazVGXPSyLtoIN7vgzVtGtb8RU9NV8hTElNja9HKtTApxTnSkthd3pMP87uzNmb8qPZ",
-	"qCowT01F50Hm5MHx+iQkp0VGFLQ7xuhUVuu/H1YdparVRxav1taqtbPRKuvj4mRdLS36LqjY/sDlbGpd",
-	"dpRch7gPuHGiRk/Vp1lHqPqpkZ5NfrX/w7XzlFpqQEuUhwg6JXX8vyD2Rt9hjeWhEcSnJ6bvE/czicop",
-	"r1rjO4Da0rS0hgKgacN19qDvCtJqZ73ky9Bz8rrxZSqlbQIkLrTGI1XQR6tSn4dvNMGFGB6Q5/R+nS1X",
-	"Bf7jJTWpmsW+y4or/y8AAP//1jcFnsEuAAA=",
+	"H4sIAAAAAAAC/9xabW/juPH/KgT/f6B3gGI52aJA/W4vaQsDi7sg2UWB3uYFLY1s7smkjqSSGoG/ezGk",
+	"HqgHx5TX7gUF9sXGGpHz8JvfDDl6pYncFlKAMJouXmnBFNuCAWX/uq2fLdN7Zjb39UN8loJOFC8Ml4Iu",
+	"WkmyvCNcEwW/l1xBSrggBTObGY0oR0H8g0ZUsC3QRbv5MqURrV+iC6NKiKhONrBluNn/K8jogv5f3Gob",
+	"u6c6XqZ0v4/ocluwxHzeFXBUWSdKzK6Aaepyb4/v1lckPA1xbS04UdVm+XMp+qVImYFwdUsrT3hKfuBC",
+	"wRaEYfmPE0woqw1PN0Ak9b50j6bgMqDNTzLl0AX4g3uCvyVSGBD2v6wocp4wtCz+ptG818Ctm4Xdxl0X",
+	"PYJICSPNazPawe+5dWlXPqyMILxNCqdPFceza1Ot+6YulUxHEYe/S6njVg9RqgL2jDpE6UIK7dD0UP1x",
+	"NuXqBe+YYWOq/QMEKJaTWguSSUV0mSSgdVbmRBag7L7aaVut20G+ZX2FkqZKCpZlkBhIf9qFIesT1wYD",
+	"lXJd5Gz3s83et1+880T3EeVpCBdFNGcryPUx2U9Oqk54xxu/4iZPEUV80wWVq2+QWK0bR1gzFq+UG9jq",
+	"CfmNu7D0F5Hvanaq9mBKsR0+v0NkDYjyXnJhkAIN38KM/FzmOVvlLoayAEEQd/gsQ67VSJKZVFtm6IIi",
+	"AK/wGbJl9WJvd20UF2u7vb9tX4uPJJdiDYoY+LchL9xsSAqG8dzSs9uQS4G7DxfuBryXNhupDGEiJe73",
+	"FRdrgsw+utQyHakkmG08q1LH+cWGTc/Ily/LO1IoyEApSGf0YBC8LSxYRzzQcF8ihcDlfW62FvjZb13U",
+	"58uol0JWMRAJhOHa6TqBxUdw7OXiWJC5NkRmldbaOtO3UqqWdL+KpSAJ04Av+KabDfZLWL8zBIwc+OmZ",
+	"J0CeQWk2+yqwqIekUhWX/TBvPJMHJJV2Qf0m2Xii/wWaCqOd1rZJvOOj4DjxNLX2AMfraQS/gjUTH81R",
+	"r9lCGv0hIQKRQhquYmjhKTZMH1XlHoUemszfR1UHqyf0qc7VgRCqojsNQE37FQ6fqjcaY866yUfO1OUK",
+	"OxFZqgQsO4gOp5g/acIrSoeUrHaWT7h3ukEK4UYT+SKIVCmo2Vfh9tZkwwqsiVwQRtb8GVqJAfkmCpiZ",
+	"goI/AqhW+2kHmC4o3AKRZ+1bGHFuPAkpdWcchJdG3ZF2R3PDn8FFuZa0TUG5XYFy9R2Nwt+sEO7elH+Z",
+	"EZitZx2UaRf+A3pxYWANqqfZeIX8VNVHT9AVybqSo1K6XLU7B5c3P4bHffipaXFZmnLUjuX3HXgPGpue",
+	"JXYBwhSQTAG4vu432JFnlpdACsaVs6zV1evIWuTc15TXbyU0F+sciKVETPxvpTY2bW1zh4lOEibIChrf",
+	"uWxHkbU9sNh4YoTrFH4EWJAATrXRHthvZcbDah+1cLFeYfkL2yGhiBSbXIbUhe3RsItrtZ0YZOsbHZxp",
+	"ztWDBqiX8J42zQ5PhwL34DegXZ98lm1gCHNxjA5GByMsAFLXZPd6sJPZ72TPno02PQ3GnNg5eQ9c+E/F",
+	"Cm3LlwJTCkhJygyzxUlUZ5Qa1RtjCr2I4zU3m3I1S+Q2fpTPoICvxW0uy/TRsOS3WBtmSn1VsDVc4eGP",
+	"FTzmWpeg47+Mlbj2dkEK+CWji1/fdsmjuxSg+yig3ZkSkQBkV+3jhMY2VDRoZf+oHigZpnHbSYUJTlq1",
+	"qbpTxN0OT6PnwxoBY11cc09EXpj2LpC8wrCSMgcm3C0UF5m0pYibHB8+3j6SR4tgcs/WQD7eL2lE8SDo",
+	"triezW3yOmDTBf0wm89uENXMbKxKcXcMsQaH7VqvZWpvu8xtK9W7e7uZzw/RQiPX3Ke5y7Byu2Vq5xau",
+	"agC2AH5dRC6XekSXW9t1tdDy75Z3hxXxrp/jwd3zfmDS9ckmOf0IIwJeOhfN+8j3dfzqTWD2Dhs5uF6/",
+	"a/Cd/d032B8VHWCfViQ+OEraP50xkk7Lwd36UTi9U3McMHUBCc944l22YDuVOngyk2yGxjk+uJh954f6",
+	"6U5ypvZijjB3d13IX29ySltOLkgq3m3hcVrxauEJzh4Oki5GLN2ZUc/n8as/Lg0gl47Z0+B6ePh7EXoZ",
+	"TsuOg+u92tTjGM+wUJa5oI0XgP4ZiGbMWTX+q37sbcZphAb+6s1QDFOWPgzf4nGebe3F2u8lqJ09w//w",
+	"8PfbDx8+/PXHZoRun7UzdI0rvDlATyFjZW7ogt7Mb26u5tdX8+vP1/OF/TebX8//dWjw1DuIY6vaVf9v",
+	"eIj8DuVBpOGq//l7VH+6HPHXsSYrMC8AgpgXSQrJ8ad6+He0INRHjVNyojfHv1wxaIf2nUyIX9tvUUKq",
+	"QGvrRC458EHNpSqA/43CsUx/n8b0qb++ig/l/csYd3Z8fz/jizBwx9685xgiqrnGewZGTWGVVSRTcjuG",
+	"l2D6qu403gVcul8TXYwUq/mYnZWPOe44mOLX+ju4CeR5bk9Hwa+OfyV4mUN+49DKy4cAGsLQ/9Me6xH9",
+	"EXeFM//7dNqFGOGcB4fjEUBiaMdIh9Db3q8PYjDWUHdGSKd8Q3tuUJoNkKRUCrsOb/pUVx7ngKP1xfdC",
+	"L/xn+QzTm2Ls9xcrFZ79eGja1CNWN5vEnf8TAAD//w4VM3WtLwAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/api/api.gen.go
+++ b/pkg/api/api.gen.go
@@ -160,9 +160,6 @@ type PhaseReference struct {
 	Order *Incremental `json:"order,omitempty"`
 }
 
-// Success An operation was successful.
-type Success = bool
-
 // ComponentIdPathParameter Identification for objects. UUID preferred.
 type ComponentIdPathParameter = Id
 
@@ -237,12 +234,6 @@ type IncrementalResponse struct {
 type PhaseListResponse struct {
 	// Data Phase resources are always handled as a list.
 	Data *PhaseList `json:"data,omitempty"`
-}
-
-// SuccessResponse defines model for SuccessResponse.
-type SuccessResponse struct {
-	// Data An operation was successful.
-	Data *Success `json:"data,omitempty"`
 }
 
 // ComponentRequest defines model for ComponentRequest.
@@ -780,42 +771,41 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/9xb62/cuBH/VwZsgd4BinbtFCi6QFHk7OthgeDOjZMvveQDVxrtMtVSCknZXRj7vxck",
-	"9aCeK+3LwQH+YEsUOY8ffzPDoV9IkGzThCNXkixeSEoF3aJCYf66K94twweqNg/FS/0uRBkIliqWcLKo",
-	"RsLyHpgEgd8yJjAExiGlauMTjzA9UP9BPMLpFsmiWnwZEo8UH5GFEhl6RAYb3FK92J8FRmRB/jSrpJ3Z",
-	"t3K2DMl+75FfkKOgWpx/Zyh2A7L+Zn6hMazLT7SY3/RnPvzsr334Z/XqH38rRDcDKtmrIWS0qDwQuEWu",
-	"aGxkXm5TGqiPuxQPGtgOBbVLcZqJmbPGqTZe8oCFY+BQDJwoajn9uQT9lIZU4XhxMzMeWAg/MF646scJ",
-	"KmT5gscrUIPI3k6DUv2UhAzrm/KDfaOfBQlXyM2vNE1jFhhczr5Krd7LyKXLie3CdRM9Ig+BQvmZT2r4",
-	"Pbcs1cz9wnBg1aaw8uR+PLs0+byDsuRjaoJY/F1KHDv7GKFyYBvZHjZU4nsmz26lcuIB/HB8hphJBUkE",
-	"qR4vfWJRLtOEywbCrZT2zSQxU5GkKFS+Y0KqxoM/V8AjGlVkQZLVVww6VXoH+d4EgSoTXAItdatWMDZ3",
-	"9ux1tTlek8ZOD68keU7gx4jMYXnfoKUrAqi+6OkIcrhNtsj2yhqd4JI+ir6mZ5wlz+CXfDbZiDhXVeUU",
-	"h/THqVfwSbXw+TyTBzvZGYlfQbszOMuN306GeD11amXLkeRczdLMQ66ihZueHIk0k7EYvBkNHrMgQCmv",
-	"JH++2lTpN1SCtJ9GWRzvQGTc5lz5xLWMqy0ajSIMFIY/7cbFC2thj4RMpjHd/WrqouEP752he4+wcEyS",
-	"4JGYrjCWh8a+t6OKUspWZL/rRb607OjVU089NVO4lRPSLb0KDX/j8a6o+/I1qBB0p9/fa0polaAPCeNK",
-	"F5eKbdGHX7M4pqsYIUoEJCly0PmzfhfpKlbq8jNKxJYqstDowTf6na5D8w8bq0slGF+b5d1lX1qwiRO+",
-	"RgEK/6fgmakNhKgoi03haxdkCdertyeuO7yR/m8SoYDyEOzzFeNr0DVz51TLsKNG1zzIonxHWbsYt0kf",
-	"Pn1a3kMqMEIhMPRJrxOcJQxYOyxQpixBwrme3s2FjQYuLxsTNdMcr7GFjGDIAxyHayvrKblZoV4B4paT",
-	"azmmNMZ0tUxElSZ85ksOgea9JKqprjYIy3sJRjtQSctOTyxAeEIhqf+ZE2/cVsr9sm/vG0flNn/WQT1I",
-	"Ns7QK9DUONppFA9jecdFwWHiKZPHHo6X0wh+hWvK36mDVjMZkPcqLkIeYjhexLGBx6QBo9KND+XO33v5",
-	"2aCckG2V2coYCLlVzmgAlfXEePjkSW0XcxbHp5ozZbYCgTLJRICGHXiNU9RfJLCc0jGE1c7wCXPOjTWF",
-	"MCUheeaQiBCF/5nbtSVsaKpjIuNAYc2esBrRIt9AIFVTUPAaQDXST03DXVDYCTxH2yGMOFXXVKQUJc0o",
-	"vJTidqQ7kin2hNbLxUiTFGTbFQob37VS+pkZpFcvw38SAfprv4Yyad3fIxfjCtcoGpJ1R8j3eXx0Btog",
-	"WURyLZTMVtXKo8Ob68PDNnxfprg0DJltWz3U4N1KbBqamAmACoRIINq87r+4gycaZwgpZcJq5h5YdiDn",
-	"oaC8ZiohGV/HmFdGTMLXTCqzbU1ypzc6BJTDCkvb2d2uhzj9N+3hYgs/Ii5gBKcab7f0r8q8NuiMkKXT",
-	"jFVo/Ex3mlB4qJNcWhwotLM4p983zcn2nHv0TrOmbiVAjQ1f6z7mK3zpc9wHNwGt2+RjUjmmqHC9Xu9o",
-	"D3PE0CbZjRzsaPY72rJno01Hgi4jFqV3V8zTJrBWeq5V2s42WiVJjJTbOl2XUWbjMqWrNPJ49wiPiqpM",
-	"wgNdI7x7WBKP6LTZLnHjz42qKXKaMrIgb/25f6utT9XGiDSrt/DXaKBfyqWLKfILqrtqVKPfcjuf9xmx",
-	"HDfrbsqYc4Rsu6ViZ1fp74GkiewQ7M4ErKqAdhueu36pnJ7orNUQ3bf0uzmsn9PhqCtlJcx7V25XZO+5",
-	"pp+9OJcZ9hYqMdpEqa7yvXnuquzeuvi9W9BqyKz3Vsb+yzGObZ5i1bW3wrb6QQdB9tpatTtuXVCVKQYs",
-	"YoFTuerYFFrAUhVs2lraDOhiip4f/CdjwGrcwIBGvz0/MC2qIeapytTjqKennzfEPa3u2RD7OGX0ER5o",
-	"X4K4IP/U22kNH8xe3Ms+Iziopvg0FPdfXbokC7X7iYcx9+qqdTRuB7nIUXEsG11Q2wvshvMRUpfNin1R",
-	"9GkHmakc1DJb4/xaUWGIRbGtLqXo1hxqmCuBpn764cO/7t6+ffv3H/2e64JSzzB4LSzEiGaxIgtyO7+9",
-	"fTO/eTO/+XgzX5gff34z/0/foX+jCNp7TfF/1gn8CcIjD8eL/tdTRD9uh3VdKhgMD4XfYYXqGZGDek4g",
-	"TZh+VDRhDoaN4vDsmG3SuKl2yZBRNfxr+2L2Ut23HBMrKm0nEkzPpdELxwn3msOh7f/KOrUukQyHh+KM",
-	"dGxsuIySZwf82aICHwf5mXMefwgg+bnzd4KTjts6Q2SX6wmRSLZdQBpNdPnZ73eBo/rN2uPos+MizQCP",
-	"5s0N0+jssuFhpM1eiuvhE/j23Eb3Rn/afXn+oocMpV1zY/dBdgyp/zEM13N/bTBCHDDe+JDxfZrwQoxx",
-	"garksCM0aVT9gT5IVz2Nqa7o/a+o49DYvrPXBqLaIASZEDpFcXoIrVv/wzHHVXmyy1v/4nCN+ODoqkut",
-	"DdavC+73+/8HAAD//9tb8WttNwAA",
+	"H4sIAAAAAAAC/9Rb64/buBH/VwZsgd4BiuzdHFDUQFHkdq8HA0Fum02+9JIPtDS2mcqUjqR2ayz8vxck",
+	"9aBeNuXXpkA+rCWKnMePv5nhMC8kSjdZypErSWYvJKOCblChML/uynfz+IGq9UP5Ur+LUUaCZYqlnMzq",
+	"kTC/ByZB4B85ExgD45BRtQ5JQJgeqH+QgHC6QTKrF5/HJCDlR2SmRI4BkdEaN1Qv9meBSzIjf5rU0k7s",
+	"WzmZx2S3C8ivyFFQLc6/chTbPbL+Zv6gCayqT7SYf+jPQvglXIXwj/rV3/9aim4G1LLXQ4i3qDwSuEGu",
+	"aGJknm8yGqlP2wwPGtgOBbXNcJyJmbPGqTae84jFPnAoB44UtZr+XIJ+zmKq0F/c3IwHFsMPjJeu+nGE",
+	"Cnmx4PEKNCCys9OgVD+nMcPmpvxo3+hnUcoVcvMnzbKERQaXk29Sq/fiuXQ1sV24aaJH5DFQqD4LSQO/",
+	"55alnnlYGA6s3hRWnsKPZ5emmHevLMWYhiAWf5cSx87uI1QBbCPbw5pKfM/k2a1UTbwHPxyfIWFSQbqE",
+	"TI+XIbEol1nKZQvhVkr7ZpSYmUgzFKrYMTFV/uAvFAiIRhWZkXTxDaNeld5BsTdBoMoFl0Ar3eoVjM2d",
+	"PXtdbY7XpLXT4ytJXhD4MSJzmN+3aOmKAGouejqCHG6THbK9skYnuGSIoq/pGWfJM/ilmE22Is5VVTnF",
+	"IcNx6hV8Ui98Ps8UwU72RuJX0O4MznLjt5MhXk+dRtlyJDnXs7TzkKto4aYnRyLNZCwGbzZrKaZu5Cxd",
+	"4ehyiZHC+OetH+NaGQMSM5kldPvBVBb7P7x3hu4CwmKfMBuQhC4wkYfGvrejymLE1jS/60W+duwYNJM3",
+	"PTVTuJEjEha9Co1/48m2rJyKNagQdKvf3+tN1SniHlLGlS7PFNtgCB/yJKGLBGGZCkgz5KAzUP1uqetA",
+	"qQu4ZSo2VJGZxg++0e90JVd82FpdKsH4yizvLvvSgU2S8hUKUPhfBc9MrSFGRVliSke7IEu5Xr07cdPh",
+	"rQR6nQoFlMdgny8YX4GuOnunmsc9Va5mErYs9pS1i3GbDOHz5/k9ZAKXKATGIRl0grOEAWuPBaqgH6Wc",
+	"6+ndbNJo4DKbMVE7UQhaW8gIhjxCP1xbWU/Jbkr1ShB3nNzI0qQxpqtlKupA+4XPOUSaOdJlQ3W1Rpjf",
+	"SzDagUo7dnpiEcITCknDL5wEflup8Muuu28clbsM2gT1XrJxhl6Bpvxop5V++/KOi4LDxFOlXwMcL8cR",
+	"/AJXlL9TB61mcojgVVyEPMbYX0TfwGMCqVfA/ljt/F1QnK7JEflKFe99IOTWCd4AqjJyf/gUaWEfc5YH",
+	"kJozZb4AgTLNRYSGHXiDU9RfJLCC0jGGxdbwCXNOXjWFMCUhfeaQihhF+IXbtSWsaaZjIuNAYcWesB7R",
+	"Id9IIFVjUPAaQDXSj01kXVDYCQJH230YceqWsUgpiwIvvFTi9qQ7kin2hNbL5UiTFOSbBQob37VS+pkZ",
+	"pFevwn+6BAxXYQNl0rp/QC7GFa5QtCTrj5Dvi/joDLRBsozkWiiZL+qVvcOb68PDNnxfpbg0jplt/Dw0",
+	"4N1JbFqamAmACoSlQLR53X9wC080yREyyoTVzD3y60HOQ0l57VRCMr5KsKgtmIRvuVRm25rkTm90iCiH",
+	"BVa2s7tdD3E6WNrD5RZ+RJyBB6cab3f0rwulLuiMkJXTjFVo8ky3mlB4rJNcWpbk3SzO6ZiNc7I9Kfbe",
+	"adbUnQSoteEb/btiha9DjvvoJqBNm3xKa8eUNWIw6B3tYY4Y2yS7lYMdzX5HW/ZstOlI8LW3utbFj9lu",
+	"TOnaijzePcKjoiqX8EBXCO8e5iQgOtm1Zr0Jp0bADDnNGJmRt+E0vNU2o2ptzDVptq5XaACrDWrk0CUQ",
+	"+RXVXT2q1We4nU6HVK/GTfqbEab6zzcbKrZ2leGz/yyVPYLdmTBTl71uo287LJXTC5x0GoG7jn43h/Vz",
+	"TvabSlkJi56N2w3YBa7pJy9OE39nt0eCNr1pqnxvnrsqu7cNfu8XtB4yGbyNsPvaUfynngI6jyKUcpkn",
+	"IXxI4a44aWoqbWXstD8OYuuiyoxB6V6EygwjtmSRU2bqQBJbnFIVrbta2nTlYoqeH/PHut4q2nK9xrqt",
+	"8U0jZh/P1KXkcUQz0LXaxzSdHtE+rnFK3SMM3231X5Btmk2jlg8mL+6VFg/GaSg+DrzDF3QuwDndZtlh",
+	"qF1Wo1Go9WMeR0Vf7rmgthfYBCfTT5+pyl1Q9h738lA1qGOtlliKCkMjim10cUM35pjBXHMzFc0PH/95",
+	"9/bt27/9GA5cgZN6hr1XnWJc0jxRZEZup7e3b6Y3b6Y3n26mM/MvnN5M/z10DN8qS3ZBW/xfdEp9gvDI",
+	"Y3/RfzpF9OM2Vl+jfG8wKP0OC1TPiBzUcwpZyvSjsi1yMEiUx1nH7I7W7atLBoi6id3YF5OX+g6hT2So",
+	"tR3JKwMXIS8TFdyO/aFdf0lVRqDWMxiUh5W+keAySp4d56fGAO4H8IlzHn4IF8W573cCj577JvuordAT",
+	"liLd9OHHm9aKs9fvAj7Nu6HHkWXPVZA9rFk0F0yjsc+Gh5E2eSkvOI9g13MbPfD+tP/69yWOCypzFjYe",
+	"QqoPhf8f2Gv0VveLBweM5x8gvk8TXogozldxHLa/poj6NH4IyXUHYawHBv8Xz3Eg7N4x6+JPrRGiXAid",
+	"hzgn9p1b6vsjjKvyaE93ruRfIxo4uuoyao2t62273f8CAAD//x09KakdNgAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/api/api.gen.go
+++ b/pkg/api/api.gen.go
@@ -53,8 +53,10 @@ type Id = string
 // Impact An impact connects a component and an incident with an impact type.
 type Impact struct {
 	// Reference Identification for objects. UUID preferred.
-	Reference *Id         `json:"reference,omitempty"`
-	Type      *ImpactType `json:"type,omitempty"`
+	Reference *Id `json:"reference,omitempty"`
+
+	// Type Identification for objects. UUID preferred.
+	Type *Id `json:"type,omitempty"`
 }
 
 // ImpactComponentList A list of impacts for an incident.
@@ -795,27 +797,27 @@ var swaggerSpec = []string{
 	"4FlrA5yQFSTi2Ni3ZlSHFYM68dRlXsJOjCBbisiS+D1L9kXXZ9cgnJO9en+v4qjVhj6klEnVXUq6gxC9",
 	"y5OErBJA65SjNAOGFHtW79aqkxWq/1ynfEckXij0wCv1TjWi9sPG6kJyyjZ6eXfZ5xZokpRtgCMJ/5Xo",
 	"icotikESmujO1yyoWVTXxHX3Nsj/NuUSERYj83xF2QapprlzqmXc0acrKNG1jShjF+02EaJPn5b3KOOw",
-	"Bs4h7p5SQ7JD47KuRyljajqX+WqJ3eSlTdLkAkEjYLQgwCLwQ62R9RQCU6jXQm/LuzVGJrQV3UL6mS3t",
-	"m1IHt5H5zHDgFxHW3Ic2/Dtyg7+gVUvSJWnFZ6YIeixuHRe083c9qAZTmzP0CkmxHywlv/fNci4GPcxV",
-	"8Lt2PdF1xHO5Rlce4BVsCHsjjxpLs5XgRTwDLIbYX0Tf6qartxdL+FAmoENg9yTFCHpUkoxqA/MPJeWX",
-	"Liw1AtkPSSX398eRJaBdCdzu3FKVukW+QhxEmvMIkEyb2U3+RSBqKwnEaLVHclslDrS81xmfSoHSp4Ls",
-	"fWZmbYG2JFOlmDJE0IZ+h2pEqwZEHIgcg4KXAOok3uyCwkwwhAunKxqLjqLl8MJIKWIHsxJUEVjj2WKk",
-	"5h/5bgXcUAmliHqmB6nVS6aRrhGEm7CGLFthrByUSdgAb0jSXdre2sLmDDTVrShjSgiRr6qVvCuZ66fj",
-	"NntbcmUSx9QcjD3UINziUA1N9ASIcEBrDmAo439gj76TJAeUEcqNZu5OaAdSHoq01uQAgrJNArZpoQJ9",
-	"zYXUoal5owpmFBGGVlBRAB3Raohzwqc8WoTpI8ACeeRN17uV/lUH1gaZFrJ0mrYKSZ7IXiUNFiv+TIoG",
-	"v00YJ26H2pIgvCPLmLpFyhpBbSf90uerDy69rZvhY+rQMdtvBr0OUU5lALGh7A1GNTmpTTbmmbJhTYIv",
-	"nZ26aqV0hFGpOjX8ePeIHiWRuUAPZAPozcMSB/g7cGHMehPOtYAZMJJRvMCvw3l4q2xG5Faba1Y/zd+A",
-	"xqgyqJZDNVT4d6jYlMCNE5fb+bxP9XLcrPtYRu8k5Lsd4XuzSv8pSJaKDsHudK2smmj3yHPfL5VzKjpr",
-	"HYkeWvrdHNfPORioK2UktKdX7rnIIXBNP3t27jUcTHgkYFhLXeV7/dxV2b2A8Ue3oNWQWe8FjcOXluK/",
-	"dLTjeRSBEOs8CdG7FN3ZXau60kbG1kHQUWxdVJkxKB1EqMggomsaOc2+qh2xwSmR0batpWEkF1P0/Jif",
-	"6nqjaMP1CuumH9cnOUN5pmoVpyWanmOvoUzTOmQayjVOKzvB8O1LDxfMNvVTp4YPZs/uLR+PjFNTfBx4",
-	"++8sXSDntE/bjkPtshqNQq1f5nFU9M09F9T2AkFwcvrpMlURBcVm32AeKge1rNUQSxKu04ikO9XPkJ3e",
-	"PdA3/3QT89OHf969fv36bz+HPbcChZph8NJXDGuSJxIv8O389vbV/ObV/ObjzXyhf8L5zfzffZv6jU7k",
-	"EDTF/01R6hOEBxb7i/7LKaJPC6yuk/bBYlD4Ha1APgEwJJ9SlKVUPSoOWY4WiWKXakp0NO6hXbJAVKfg",
-	"tbiYPVfXKn0qQ6XtyLzSczf0MlXBPfI/FvWXVGUEaj2LQbEH6VsJLqPk2XF+ag1gfgCfOdvcx3Bht3N/",
-	"EHh0XFgZSm1WT7Tm6a4LP95pzW6v/hDwqd+SnZQs63dJBvKlPS2QaY/1jmNs9uzc8x6RWs9t8cD7097r",
-	"8JfYLiiNai3dh1SfFP7/YbLR0e5XEo7Yz79G/LBWvFC6OF/fcdwFKl1U2/B9eK6ODsY6offfm6bhsH1r",
-	"rQ1BuQUU5ZwrNuLs27du7Q/XGVfl0Z5u/YvCpJrQcWd9oDA4qqpeaguN+3KHw/8CAAD//xi7R8c1NwAA",
+	"Bs4h7p5SQ7JD47KuRyljajqX+WqJ3eSlTdLkAkEjYLQgwCLwQ62RdQqXLNRqobbl1RoTE9p6bgH9zJb2",
+	"TSm728B8ZjjwiwRr5kMb9h05wV/QqhXpkrTiMVMEPRavDnds5+16MA2mNGfoFZJhP1hKXu+b3Vzy7GGu",
+	"gte164iuH57LNbrxAK9gQ9gbedRYmqUEL+IZYDHE/iL6VjVdtb3YwYcy8RwCuxcpRtCiklxUG5d/KCm/",
+	"dGGpEch+SCo5vz+OLPHsStx2x5aqlC3yFeIg0pxHgGTazG7yLwJRW0EgRqs9ktsqcaDlvc70VAqUPhUk",
+	"7zMzawu0JZkqwZQhgjb0O1QjWrk/4kDkGBS8BFAn8WUXFGaCIVw43dBYdBSthhdGShE7GJWgirgazxYj",
+	"Ne/IdyvghkIoRdQzPUitXjKMdI0g3IQ1ZNkKY+WgTMIGeEOS7tL21hY2Z6CpbkUZU0KIfFWt5F3JXD8d",
+	"t9nbkiOTOKbmQOyhBuEWd2pooidAhANacwBDFf8De/SdJDmgjFBuNHN3QDuQ8lCktSYHEJRtErDNChXo",
+	"ay6kDk3NF1Uwo4gwtIKKAuiIVkOckz3l0SJMHwEWyCNvut6t9K86rzbItJCl07RVSPJE9ippsFjxZlI0",
+	"9m2iOHEb1JYE4R1ZxtQtUtYIajvplz5ffXBpbd0MH1OHjtk+M+h1iHIqA4gNVW8wqslJbbIxz5QNaxJ8",
+	"6ezQVQulI4xK1aHhx7tH9CiJzAV6IBtAbx6WOMDfgQtj1ptwrgXMgJGM4gV+Hc7DW2UzIrfaXLP6Kf4G",
+	"NEaVQbUcqpHCv0PFpgRunLTczud9qpfjZt3HMXoHId/tCN+bVfpPP7JUdAh2p2tl1Ty7R537fqmc09BZ",
+	"6yj00NLv5rh+zoFAXSkjoT21cs9DDoFr+tmzc5/hYMIjAcNa6irf6+euyu7Fiz+6Ba2GzHovZhy+tBT/",
+	"paMNz6MIhFjnSYjepejO7lbVlTYytg6AjmLrosqMQekgQkUGEV3TyGnyVe2IDU6JjLZtLQ0juZii58f8",
+	"VNcbRRuuV1g3/bg+wRnKM1WrOC3R9Bx3DWWa1uHSUK5xWtkJhm9fdrhgtqmfNjV8MHt2b/d4ZJya4uPA",
+	"239X6QI5p33Kdhxql9VoFGr9Mo+jom/uuaC2FwiCk9NPl6mKKCg2+wbzUDmoZa2GWJJwnUYk3al+huz0",
+	"7oG+8aebmJ8+/PPu9evXf/s57LkNKNQMg5e9YliTPJF4gW/nt7ev5jev5jcfb+YL/RPOb+b/7tvMb3Qi",
+	"h6Ap/m+KUp8gPLDYX/RfThF9WmB1nbAPFoPC72gF8gmAIfmUoiyl6lFxuHK0SBS7VFOio3H/7JIFojr9",
+	"rsXF7Lm6TulTGSptR+aVnjuhl6kK7lH/sai/pCojUOtZDIo9SN9KcBklz47zU2sA8wP4zNnmPoYLu537",
+	"g8Cj46LKUGqzeqI1T3dd+PFOa3Z79YeAT/127KRkWb9DMpAv7WmBTHusdxxjs2fnfveI1Hpuiwfen/Ze",
+	"g7/EdkFpVGvpPqT6pPD/D5ONjna/knDEfv414oe14oXSxfn6juMuUOmi2obvw3N1dDDWCb3/1jQNh+3b",
+	"am0Iyi2gKOdcsRFn3751W3+4zrgqj/Z0618TJtWEjrvqA4XBUVX1Ulto3JM7HP4XAAD//2AYIn0tNwAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/api/api.gen.go
+++ b/pkg/api/api.gen.go
@@ -84,30 +84,30 @@ type PutPhasesJSONRequestBody = PutPhasesJSONBody
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
-	// Create a new component
-	// (POST /component)
-	CreateComponent(ctx echo.Context) error
-	// get specific component by id
-	// (GET /component/{componentId})
-	GetComponent(ctx echo.Context, componentId string) error
 
 	// (GET /components)
 	GetComponents(ctx echo.Context) error
-	// Create a new impact type
-	// (POST /impacttype)
-	CreateImpactType(ctx echo.Context) error
+	// Create a new component
+	// (POST /components)
+	CreateComponent(ctx echo.Context) error
+	// Get specific component by id
+	// (GET /components/{componentId})
+	GetComponent(ctx echo.Context, componentId string) error
 
 	// (GET /impacttypes)
 	GetImpacttypes(ctx echo.Context) error
-	// create a new incident
-	// (POST /incident)
-	CreateIncident(ctx echo.Context) error
-	// Get specific incident by id
-	// (GET /incident/{incidentId})
-	GetIncident(ctx echo.Context, incidentId string) error
+	// Create a new impact type
+	// (POST /impacttypes)
+	CreateImpactType(ctx echo.Context) error
 	// Get list of incidents
 	// (GET /incidents)
 	GetIncidents(ctx echo.Context, params GetIncidentsParams) error
+	// Create a new incident
+	// (POST /incidents)
+	CreateIncident(ctx echo.Context) error
+	// Get specific incident by id
+	// (GET /incidents/{incidentId})
+	GetIncident(ctx echo.Context, incidentId string) error
 
 	// (GET /phases)
 	GetPhases(ctx echo.Context) error
@@ -119,6 +119,15 @@ type ServerInterface interface {
 // ServerInterfaceWrapper converts echo contexts to parameters.
 type ServerInterfaceWrapper struct {
 	Handler ServerInterface
+}
+
+// GetComponents converts echo context to params.
+func (w *ServerInterfaceWrapper) GetComponents(ctx echo.Context) error {
+	var err error
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.GetComponents(ctx)
+	return err
 }
 
 // CreateComponent converts echo context to params.
@@ -146,24 +155,6 @@ func (w *ServerInterfaceWrapper) GetComponent(ctx echo.Context) error {
 	return err
 }
 
-// GetComponents converts echo context to params.
-func (w *ServerInterfaceWrapper) GetComponents(ctx echo.Context) error {
-	var err error
-
-	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.GetComponents(ctx)
-	return err
-}
-
-// CreateImpactType converts echo context to params.
-func (w *ServerInterfaceWrapper) CreateImpactType(ctx echo.Context) error {
-	var err error
-
-	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.CreateImpactType(ctx)
-	return err
-}
-
 // GetImpacttypes converts echo context to params.
 func (w *ServerInterfaceWrapper) GetImpacttypes(ctx echo.Context) error {
 	var err error
@@ -173,28 +164,12 @@ func (w *ServerInterfaceWrapper) GetImpacttypes(ctx echo.Context) error {
 	return err
 }
 
-// CreateIncident converts echo context to params.
-func (w *ServerInterfaceWrapper) CreateIncident(ctx echo.Context) error {
+// CreateImpactType converts echo context to params.
+func (w *ServerInterfaceWrapper) CreateImpactType(ctx echo.Context) error {
 	var err error
 
 	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.CreateIncident(ctx)
-	return err
-}
-
-// GetIncident converts echo context to params.
-func (w *ServerInterfaceWrapper) GetIncident(ctx echo.Context) error {
-	var err error
-	// ------------- Path parameter "incidentId" -------------
-	var incidentId string
-
-	err = runtime.BindStyledParameterWithLocation("simple", false, "incidentId", runtime.ParamLocationPath, ctx.Param("incidentId"), &incidentId)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter incidentId: %s", err))
-	}
-
-	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.GetIncident(ctx, incidentId)
+	err = w.Handler.CreateImpactType(ctx)
 	return err
 }
 
@@ -220,6 +195,31 @@ func (w *ServerInterfaceWrapper) GetIncidents(ctx echo.Context) error {
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.GetIncidents(ctx, params)
+	return err
+}
+
+// CreateIncident converts echo context to params.
+func (w *ServerInterfaceWrapper) CreateIncident(ctx echo.Context) error {
+	var err error
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.CreateIncident(ctx)
+	return err
+}
+
+// GetIncident converts echo context to params.
+func (w *ServerInterfaceWrapper) GetIncident(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "incidentId" -------------
+	var incidentId string
+
+	err = runtime.BindStyledParameterWithLocation("simple", false, "incidentId", runtime.ParamLocationPath, ctx.Param("incidentId"), &incidentId)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter incidentId: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.GetIncident(ctx, incidentId)
 	return err
 }
 
@@ -269,14 +269,14 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 		Handler: si,
 	}
 
-	router.POST(baseURL+"/component", wrapper.CreateComponent)
-	router.GET(baseURL+"/component/:componentId", wrapper.GetComponent)
 	router.GET(baseURL+"/components", wrapper.GetComponents)
-	router.POST(baseURL+"/impacttype", wrapper.CreateImpactType)
+	router.POST(baseURL+"/components", wrapper.CreateComponent)
+	router.GET(baseURL+"/components/:componentId", wrapper.GetComponent)
 	router.GET(baseURL+"/impacttypes", wrapper.GetImpacttypes)
-	router.POST(baseURL+"/incident", wrapper.CreateIncident)
-	router.GET(baseURL+"/incident/:incidentId", wrapper.GetIncident)
+	router.POST(baseURL+"/impacttypes", wrapper.CreateImpactType)
 	router.GET(baseURL+"/incidents", wrapper.GetIncidents)
+	router.POST(baseURL+"/incidents", wrapper.CreateIncident)
+	router.GET(baseURL+"/incidents/:incidentId", wrapper.GetIncident)
 	router.GET(baseURL+"/phases", wrapper.GetPhases)
 	router.PUT(baseURL+"/phases", wrapper.PutPhases)
 
@@ -285,21 +285,21 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/8xXTY/bNhD9KwTbQwtobdnbS3VLjDYQGjRGnV4a7IEWR14GEsmQVFvB0H8vSEkW9bGy",
-	"tu5uAyyw+hjOvHnz+ESfcSJyKThwo3F0xjp5hJy4y137wt5IJSQow8C9ImkKiQH6trR3zEDuHn+rIMUR",
-	"/mbd5Vw3CdcxxVWATSkBR5goRUp7T5mWGSl/JTnYBM1rbRTjJ/ueUftYAaEfeFbiyKgCgnFYRo6QXYXw",
-	"vo6qqgAr+FIwBRRHn2yNPpBLvsBv9OFSVxw/Q2Js3ZhOoo55wugMcfpG1o5wIvyNS58KlRODI0yJgTvD",
-	"HPwRIAo6UUwaJvgkYOAU6ExCXmQZOWbw5AAWzonlkiTmo3t8pfGGwrhbUQVYPhK9eOneBVv6mMmm5VVI",
-	"2+UzxtGk/t2tG49mSll19f4MusrBRRI9dtpWJ0U3pmZOhPuWsycjmm5GYk0UEDOri1FKA3+biVoDXlxU",
-	"4OWfavP9ZU8TSpmljWT7Hr5x9X4OW5bxVLjYWgP4sDuggyGm0GhPToDe7GMc4D9Babc38GYV2kxCAieS",
-	"4Qjfr8LV1s6DmEdXtdOFY0xo99/iIhaktQS8c511Blq3D9q8FdRZZiK4aTIQKTOWuLXrz7reoLXerqmx",
-	"y19VNcVaCq5rcrbh5lmFhhMbukbTE3XD1EWeE1VeniKCOPyFEg9Q4BG1Pl8uY1rZaieYYO0dGJ8ySRTJ",
-	"wYDSOPp0xsyCsFOwfuS+F9jLin2F1e7zdG8PI67ClxnKkMMPvwzoO4FBWkLCUpZ09KFjiRgdkKgX8abx",
-	"jb0t8kGvyZEFTjfteqkNzjSONbd1Yt8KX2LvTH1fvo5NVJOETA2px9qsBGIv7DU0MP2FfoYY/EPSnBTa",
-	"uJcVwv84/qQ3/g6PR9L63F5dMVCPrev+2eX8auzTH8dV93znu2fbjG+e7TO9hDI95qxf/2CIMkikyJ5+",
-	"UGojkRHoSwGqRKlQ6Lvfft7d39//+L09zNkV7lXHt7YJZqmmkJIis8esbbjd3oWbu3DzcRNG7m8VbsI/",
-	"cLDoKFYFQ/Q/cXoLduB0OfIfbkH+8JrutdizhrrLmHZa6CTmFOeO7bNy29cRr9lk90tokTsHWBYT2PeF",
-	"j/3fOfF/A7u6kbwm31GIDAhfNPLeJ7qdfT3slYP0TwAAAP//9637PkkRAAA=",
+	"H4sIAAAAAAAC/8xXUY+jNhD+K5bbh1ZiA0n6Ut7uovaEeupFzfWlp31w8JD1CWyfbdqiiP9e2SYBAktI",
+	"c7daaR8Aj2e+mfm+mc0Rp6KQggM3GsdHrNMnKIh73JwO7ItUQoIyDNwRyTJIDdC3lX1jBgr3+XsFGY7x",
+	"d2HrM2wchgnFdYBNJQHHmChFKvtOmZY5qX4nBVgHzbE2ivGDPWfUflZA6AeeVzg2qoRgaJaTPeRXIbz3",
+	"VnUdYAVfSqaA4viTjdEHcvYXdBN9PMcV+8+QGhs3oaOoE54yOlE4fWfV9nAg/I1znwlVEINjTImBB8Mc",
+	"/AEgCjpVTBom+Chg4BTohENe5jnZ5/BsA2b2iRWSpOaj+3wl8aaESXujDrB8Inr21a0ztuVjJh+nVylt",
+	"lje0o3H9p7s3bM0Ys3z0fg/ayMGZEr3qnFIdJd2wNFMk3J5q9qxFk82ArKkCYiZ5MXBp4F8zEuuiLs4q",
+	"6PgfS/P9WdOEUmbLRvJtD98wet+HDct4Jpyt5wDebXZoZ4gpNdqSA6A32wQH+G9Q2mkDLxeR9SQkcCIZ",
+	"jvF6ES1Wth/EPLmoYX9gHsAlbHERC9KOBPwOzKa1sslrKbj2sFdR5KoruGlmBJEyZ6m7Hn7WXqOecrOZ",
+	"2Q7rISkvBwD+8Jv/KoUeAb9xbWkd+t6BNm8FrW5CPhNw7fnRK9HypkCXdBtk7HOijom6LAqiqvNXRBCH",
+	"f1DaARR0uxwez88JrWf13PFFkQIMKI3jT0fMLArLITtN3bbDHa+4qw8/O59P7vFOPs3uyihtuvV7BwZp",
+	"CSnLWNrWD+0rxHypQz/SbAaTYkk6Zi+hlvHt8jVkk3Rn+LfQzRj01yEg32tkPCTb/AbqdOvPRgPN9BHs",
+	"DFEGiQzZ3YMya4mMQF9KUBXKhEI//PHrZr1e//yjXaX2hjtq9aatg0mlUchImdslt4pWq4do+RAtPy6j",
+	"2P0tomX0Fw5mLcI6uET/C6f3YAdO5yP/6R7kjy+pv9mqu5w6OdOOCy3FrunyFPHbqvLVaLHF0xVieDw9",
+	"XtlknXJdX2Stz1ezx7r9uG2NnZLpbjH3v/jkFNt6i5fUTvvzZu7aKkewb8su9v8njK8Du76zeI2/vRA5",
+	"ED6r8T3JnEaKb/bCQfovAAD//weRkBYeEQAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/api/api.gen.go
+++ b/pkg/api/api.gen.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -161,17 +160,6 @@ type PhaseReference struct {
 	Order *Incremental `json:"order,omitempty"`
 }
 
-// ResponseData Wraps the retuned data in an object.
-// See: https://github.com/SovereignCloudStack/status-page-openapi/issues/6
-type ResponseData struct {
-	Content *ResponseData_Content `json:"content,omitempty"`
-}
-
-// ResponseData_Content defines model for ResponseData.Content.
-type ResponseData_Content struct {
-	union json.RawMessage
-}
-
 // Success An operation was successful.
 type Success = bool
 
@@ -187,9 +175,72 @@ type IncidentIdPathParameter = Id
 // IncidentUpdateIdPathParameter Positive and incrementing number for ordering and identfication of e.g. sub resources.
 type IncidentUpdateIdPathParameter = Incremental
 
-// Response Wraps the retuned data in an object.
-// See: https://github.com/SovereignCloudStack/status-page-openapi/issues/6
-type Response = ResponseData
+// ComponentListResponse defines model for ComponentListResponse.
+type ComponentListResponse struct {
+	Data *ComponentList `json:"data,omitempty"`
+}
+
+// ComponentResponse defines model for ComponentResponse.
+type ComponentResponse struct {
+	Data *Component `json:"data,omitempty"`
+}
+
+// IdResponse defines model for IdResponse.
+type IdResponse struct {
+	// Data Identification for objects. UUID preferred.
+	Data *Id `json:"data,omitempty"`
+}
+
+// ImpactTypeListResponse defines model for ImpactTypeListResponse.
+type ImpactTypeListResponse struct {
+	Data *ImpactTypeList `json:"data,omitempty"`
+}
+
+// ImpactTypeResponse defines model for ImpactTypeResponse.
+type ImpactTypeResponse struct {
+	Data *ImpactType `json:"data,omitempty"`
+}
+
+// IncidentListResponse defines model for IncidentListResponse.
+type IncidentListResponse struct {
+	Data *IncidentList `json:"data,omitempty"`
+}
+
+// IncidentResponse defines model for IncidentResponse.
+type IncidentResponse struct {
+	Data *Incident `json:"data,omitempty"`
+}
+
+// IncidentUpdateListResponse defines model for IncidentUpdateListResponse.
+type IncidentUpdateListResponse struct {
+	Data *IncidentUpdateList `json:"data,omitempty"`
+}
+
+// IncidentUpdateResponse defines model for IncidentUpdateResponse.
+type IncidentUpdateResponse struct {
+	// Data An update is a sub resource to an incident.
+	// It's identified by the incident ID and its own order.
+	// Updates happen in a given order.
+	Data *IncidentUpdate `json:"data,omitempty"`
+}
+
+// IncrementalResponse defines model for IncrementalResponse.
+type IncrementalResponse struct {
+	// Data Positive and incrementing number for ordering and identfication of e.g. sub resources.
+	Data *Incremental `json:"data,omitempty"`
+}
+
+// PhaseListResponse defines model for PhaseListResponse.
+type PhaseListResponse struct {
+	// Data Phase resources are always handled as a list.
+	Data *PhaseList `json:"data,omitempty"`
+}
+
+// SuccessResponse defines model for SuccessResponse.
+type SuccessResponse struct {
+	// Data An operation was successful.
+	Data *Success `json:"data,omitempty"`
+}
 
 // ComponentRequest defines model for ComponentRequest.
 type ComponentRequest = Component
@@ -245,328 +296,6 @@ type UpdateIncidentUpdateJSONRequestBody = IncidentUpdate
 
 // CreatePhaseListJSONRequestBody defines body for CreatePhaseList for application/json ContentType.
 type CreatePhaseListJSONRequestBody = PhaseList
-
-// AsSuccess returns the union data inside the ResponseData_Content as a Success
-func (t ResponseData_Content) AsSuccess() (Success, error) {
-	var body Success
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromSuccess overwrites any union data inside the ResponseData_Content as the provided Success
-func (t *ResponseData_Content) FromSuccess(v Success) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeSuccess performs a merge with any union data inside the ResponseData_Content, using the provided Success
-func (t *ResponseData_Content) MergeSuccess(v Success) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JsonMerge(b, t.union)
-	t.union = merged
-	return err
-}
-
-// AsId returns the union data inside the ResponseData_Content as a Id
-func (t ResponseData_Content) AsId() (Id, error) {
-	var body Id
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromId overwrites any union data inside the ResponseData_Content as the provided Id
-func (t *ResponseData_Content) FromId(v Id) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeId performs a merge with any union data inside the ResponseData_Content, using the provided Id
-func (t *ResponseData_Content) MergeId(v Id) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JsonMerge(b, t.union)
-	t.union = merged
-	return err
-}
-
-// AsIncremental returns the union data inside the ResponseData_Content as a Incremental
-func (t ResponseData_Content) AsIncremental() (Incremental, error) {
-	var body Incremental
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromIncremental overwrites any union data inside the ResponseData_Content as the provided Incremental
-func (t *ResponseData_Content) FromIncremental(v Incremental) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeIncremental performs a merge with any union data inside the ResponseData_Content, using the provided Incremental
-func (t *ResponseData_Content) MergeIncremental(v Incremental) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JsonMerge(b, t.union)
-	t.union = merged
-	return err
-}
-
-// AsPhaseList returns the union data inside the ResponseData_Content as a PhaseList
-func (t ResponseData_Content) AsPhaseList() (PhaseList, error) {
-	var body PhaseList
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromPhaseList overwrites any union data inside the ResponseData_Content as the provided PhaseList
-func (t *ResponseData_Content) FromPhaseList(v PhaseList) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergePhaseList performs a merge with any union data inside the ResponseData_Content, using the provided PhaseList
-func (t *ResponseData_Content) MergePhaseList(v PhaseList) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JsonMerge(b, t.union)
-	t.union = merged
-	return err
-}
-
-// AsImpactType returns the union data inside the ResponseData_Content as a ImpactType
-func (t ResponseData_Content) AsImpactType() (ImpactType, error) {
-	var body ImpactType
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromImpactType overwrites any union data inside the ResponseData_Content as the provided ImpactType
-func (t *ResponseData_Content) FromImpactType(v ImpactType) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeImpactType performs a merge with any union data inside the ResponseData_Content, using the provided ImpactType
-func (t *ResponseData_Content) MergeImpactType(v ImpactType) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JsonMerge(b, t.union)
-	t.union = merged
-	return err
-}
-
-// AsImpactTypeList returns the union data inside the ResponseData_Content as a ImpactTypeList
-func (t ResponseData_Content) AsImpactTypeList() (ImpactTypeList, error) {
-	var body ImpactTypeList
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromImpactTypeList overwrites any union data inside the ResponseData_Content as the provided ImpactTypeList
-func (t *ResponseData_Content) FromImpactTypeList(v ImpactTypeList) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeImpactTypeList performs a merge with any union data inside the ResponseData_Content, using the provided ImpactTypeList
-func (t *ResponseData_Content) MergeImpactTypeList(v ImpactTypeList) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JsonMerge(b, t.union)
-	t.union = merged
-	return err
-}
-
-// AsComponent returns the union data inside the ResponseData_Content as a Component
-func (t ResponseData_Content) AsComponent() (Component, error) {
-	var body Component
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromComponent overwrites any union data inside the ResponseData_Content as the provided Component
-func (t *ResponseData_Content) FromComponent(v Component) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeComponent performs a merge with any union data inside the ResponseData_Content, using the provided Component
-func (t *ResponseData_Content) MergeComponent(v Component) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JsonMerge(b, t.union)
-	t.union = merged
-	return err
-}
-
-// AsComponentList returns the union data inside the ResponseData_Content as a ComponentList
-func (t ResponseData_Content) AsComponentList() (ComponentList, error) {
-	var body ComponentList
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromComponentList overwrites any union data inside the ResponseData_Content as the provided ComponentList
-func (t *ResponseData_Content) FromComponentList(v ComponentList) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeComponentList performs a merge with any union data inside the ResponseData_Content, using the provided ComponentList
-func (t *ResponseData_Content) MergeComponentList(v ComponentList) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JsonMerge(b, t.union)
-	t.union = merged
-	return err
-}
-
-// AsIncident returns the union data inside the ResponseData_Content as a Incident
-func (t ResponseData_Content) AsIncident() (Incident, error) {
-	var body Incident
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromIncident overwrites any union data inside the ResponseData_Content as the provided Incident
-func (t *ResponseData_Content) FromIncident(v Incident) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeIncident performs a merge with any union data inside the ResponseData_Content, using the provided Incident
-func (t *ResponseData_Content) MergeIncident(v Incident) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JsonMerge(b, t.union)
-	t.union = merged
-	return err
-}
-
-// AsIncidentList returns the union data inside the ResponseData_Content as a IncidentList
-func (t ResponseData_Content) AsIncidentList() (IncidentList, error) {
-	var body IncidentList
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromIncidentList overwrites any union data inside the ResponseData_Content as the provided IncidentList
-func (t *ResponseData_Content) FromIncidentList(v IncidentList) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeIncidentList performs a merge with any union data inside the ResponseData_Content, using the provided IncidentList
-func (t *ResponseData_Content) MergeIncidentList(v IncidentList) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JsonMerge(b, t.union)
-	t.union = merged
-	return err
-}
-
-// AsIncidentUpdate returns the union data inside the ResponseData_Content as a IncidentUpdate
-func (t ResponseData_Content) AsIncidentUpdate() (IncidentUpdate, error) {
-	var body IncidentUpdate
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromIncidentUpdate overwrites any union data inside the ResponseData_Content as the provided IncidentUpdate
-func (t *ResponseData_Content) FromIncidentUpdate(v IncidentUpdate) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeIncidentUpdate performs a merge with any union data inside the ResponseData_Content, using the provided IncidentUpdate
-func (t *ResponseData_Content) MergeIncidentUpdate(v IncidentUpdate) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JsonMerge(b, t.union)
-	t.union = merged
-	return err
-}
-
-// AsIncidentUpdateList returns the union data inside the ResponseData_Content as a IncidentUpdateList
-func (t ResponseData_Content) AsIncidentUpdateList() (IncidentUpdateList, error) {
-	var body IncidentUpdateList
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromIncidentUpdateList overwrites any union data inside the ResponseData_Content as the provided IncidentUpdateList
-func (t *ResponseData_Content) FromIncidentUpdateList(v IncidentUpdateList) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeIncidentUpdateList performs a merge with any union data inside the ResponseData_Content, using the provided IncidentUpdateList
-func (t *ResponseData_Content) MergeIncidentUpdateList(v IncidentUpdateList) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JsonMerge(b, t.union)
-	t.union = merged
-	return err
-}
-
-func (t ResponseData_Content) MarshalJSON() ([]byte, error) {
-	b, err := t.union.MarshalJSON()
-	return b, err
-}
-
-func (t *ResponseData_Content) UnmarshalJSON(b []byte) error {
-	err := t.union.UnmarshalJSON(b)
-	return err
-}
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
@@ -1044,40 +773,41 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/9xabW/juPH/KgT/f6B3gGI52aJA/W4vaQsDi7sg2UWB3uYFLY1s7smkjqSSGoG/ezGk",
-	"HqgHx5TX7gUF9sXGGpHz8JvfDDl6pYncFlKAMJouXmnBFNuCAWX/uq2fLdN7Zjb39UN8loJOFC8Ml4Iu",
-	"WkmyvCNcEwW/l1xBSrggBTObGY0oR0H8g0ZUsC3QRbv5MqURrV+iC6NKiKhONrBluNn/K8jogv5f3Gob",
-	"u6c6XqZ0v4/ocluwxHzeFXBUWSdKzK6Aaepyb4/v1lckPA1xbS04UdVm+XMp+qVImYFwdUsrT3hKfuBC",
-	"wRaEYfmPE0woqw1PN0Ak9b50j6bgMqDNTzLl0AX4g3uCvyVSGBD2v6wocp4wtCz+ptG818Ctm4Xdxl0X",
-	"PYJICSPNazPawe+5dWlXPqyMILxNCqdPFceza1Ot+6YulUxHEYe/S6njVg9RqgL2jDpE6UIK7dD0UP1x",
-	"NuXqBe+YYWOq/QMEKJaTWguSSUV0mSSgdVbmRBag7L7aaVut20G+ZX2FkqZKCpZlkBhIf9qFIesT1wYD",
-	"lXJd5Gz3s83et1+880T3EeVpCBdFNGcryPUx2U9Oqk54xxu/4iZPEUV80wWVq2+QWK0bR1gzFq+UG9jq",
-	"CfmNu7D0F5Hvanaq9mBKsR0+v0NkDYjyXnJhkAIN38KM/FzmOVvlLoayAEEQd/gsQ67VSJKZVFtm6IIi",
-	"AK/wGbJl9WJvd20UF2u7vb9tX4uPJJdiDYoY+LchL9xsSAqG8dzSs9uQS4G7DxfuBryXNhupDGEiJe73",
-	"FRdrgsw+utQyHakkmG08q1LH+cWGTc/Ily/LO1IoyEApSGf0YBC8LSxYRzzQcF8ihcDlfW62FvjZb13U",
-	"58uol0JWMRAJhOHa6TqBxUdw7OXiWJC5NkRmldbaOtO3UqqWdL+KpSAJ04Av+KabDfZLWL8zBIwc+OmZ",
-	"J0CeQWk2+yqwqIekUhWX/TBvPJMHJJV2Qf0m2Xii/wWaCqOd1rZJvOOj4DjxNLX2AMfraQS/gjUTH81R",
-	"r9lCGv0hIQKRQhquYmjhKTZMH1XlHoUemszfR1UHqyf0qc7VgRCqojsNQE37FQ6fqjcaY866yUfO1OUK",
-	"OxFZqgQsO4gOp5g/acIrSoeUrHaWT7h3ukEK4UYT+SKIVCmo2Vfh9tZkwwqsiVwQRtb8GVqJAfkmCpiZ",
-	"goI/AqhW+2kHmC4o3AKRZ+1bGHFuPAkpdWcchJdG3ZF2R3PDn8FFuZa0TUG5XYFy9R2Nwt+sEO7elH+Z",
-	"EZitZx2UaRf+A3pxYWANqqfZeIX8VNVHT9AVybqSo1K6XLU7B5c3P4bHffipaXFZmnLUjuX3HXgPGpue",
-	"JXYBwhSQTAG4vu432JFnlpdACsaVs6zV1evIWuTc15TXbyU0F+sciKVETPxvpTY2bW1zh4lOEibIChrf",
-	"uWxHkbU9sNh4YoTrFH4EWJAATrXRHthvZcbDah+1cLFeYfkL2yGhiBSbXIbUhe3RsItrtZ0YZOsbHZxp",
-	"ztWDBqiX8J42zQ5PhwL34DegXZ98lm1gCHNxjA5GByMsAFLXZPd6sJPZ72TPno02PQ3GnNg5eQ9c+E/F",
-	"Cm3LlwJTCkhJygyzxUlUZ5Qa1RtjCr2I4zU3m3I1S+Q2fpTPoICvxW0uy/TRsOS3WBtmSn1VsDVc4eGP",
-	"FTzmWpeg47+Mlbj2dkEK+CWji1/fdsmjuxSg+yig3ZkSkQBkV+3jhMY2VDRoZf+oHigZpnHbSYUJTlq1",
-	"qbpTxN0OT6PnwxoBY11cc09EXpj2LpC8wrCSMgcm3C0UF5m0pYibHB8+3j6SR4tgcs/WQD7eL2lE8SDo",
-	"triezW3yOmDTBf0wm89uENXMbKxKcXcMsQaH7VqvZWpvu8xtK9W7e7uZzw/RQiPX3Ke5y7Byu2Vq5xau",
-	"agC2AH5dRC6XekSXW9t1tdDy75Z3hxXxrp/jwd3zfmDS9ckmOf0IIwJeOhfN+8j3dfzqTWD2Dhs5uF6/",
-	"a/Cd/d032B8VHWCfViQ+OEraP50xkk7Lwd36UTi9U3McMHUBCc944l22YDuVOngyk2yGxjk+uJh954f6",
-	"6U5ypvZijjB3d13IX29ySltOLkgq3m3hcVrxauEJzh4Oki5GLN2ZUc/n8as/Lg0gl47Z0+B6ePh7EXoZ",
-	"TsuOg+u92tTjGM+wUJa5oI0XgP4ZiGbMWTX+q37sbcZphAb+6s1QDFOWPgzf4nGebe3F2u8lqJ09w//w",
-	"8PfbDx8+/PXHZoRun7UzdI0rvDlATyFjZW7ogt7Mb26u5tdX8+vP1/OF/TebX8//dWjw1DuIY6vaVf9v",
-	"eIj8DuVBpOGq//l7VH+6HPHXsSYrMC8AgpgXSQrJ8ad6+He0INRHjVNyojfHv1wxaIf2nUyIX9tvUUKq",
-	"QGvrRC458EHNpSqA/43CsUx/n8b0qb++ig/l/csYd3Z8fz/jizBwx9685xgiqrnGewZGTWGVVSRTcjuG",
-	"l2D6qu403gVcul8TXYwUq/mYnZWPOe44mOLX+ju4CeR5bk9Hwa+OfyV4mUN+49DKy4cAGsLQ/9Me6xH9",
-	"EXeFM//7dNqFGOGcB4fjEUBiaMdIh9Db3q8PYjDWUHdGSKd8Q3tuUJoNkKRUCrsOb/pUVx7ngKP1xfdC",
-	"L/xn+QzTm2Ls9xcrFZ79eGja1CNWN5vEnf8TAAD//w4VM3WtLwAA",
+	"H4sIAAAAAAAC/9xbS48buRH+KwUmQHaBtqQZ5xLdvDNJIGCwEWbsS9Y+UN3VEp0Wu02yZyII+u8ByX6w",
+	"XxL1HCPAHtYSxXp9/KqKxdmSMF1nKUeuJJluSUYFXaNCYf71UH43i+ZUrebll/q7CGUoWKZYysm0Xgmz",
+	"R2ASBP7ImcAIGIeMqtWIBITphfofJCCcrpFMa+GziASk/BGZKpFjQGS4wjXVwv4sMCZT8qdxre3YfivH",
+	"s4jsdgGZrTMaqs+bDA8qa5eC2mR4nLrMkXG2vjxkkY9ry4VHqlptfylFv2QRVeivbm7WA4vgF8YFrpEr",
+	"mvx6hAl5IfB0A3hYyiU7bYreBqX6LY0YNgH+bL/Rn4UpV8jN/9IsS1hItWXj71Kbt/UUXW1sBTdd9II8",
+	"AgrVz0akgd9L61LvPKwMB1YfCqtPEceLa1Psu1eXYk1DEYu/a6ljd/dRqgD2iFhEySzlsoWmJybVc/HN",
+	"UZpmIs1QqAKdEVX+QNMyjUo6gmRK0sV3DHu9/AmKcwACVS64BAoJkwrSuMakNL53zsdtrTndktapim6k",
+	"eUGWp6jMYfbYooAbAqgp9HwEOTwiO8R2Y4vOCMkQHd4yMo7IC8Sl2E222P2mppwTkOGc8A4xqQVfLjJF",
+	"YpG9We8drLtAsOpcaSwqq7HbmePUfyeTc72LsWO+ovKWkKvknY60TG9h8GYseMnDEKW8kf6FtGO1X1EJ",
+	"0v40zpNkAyLntuYqNm5UXF3VaBxjqDD6beOXL6yHAxIxmSV087vpQfb/8NFZugsIi3yKhIAkdIGJPLT2",
+	"ya4q2xbb/fyhhXzr+DFolp56a6ZwLY8ot7QUGv2LJ5uyxypkUCHoRn//qCmh0+7NU8aVbuQUW+MIfs+T",
+	"hC4ShDgVkGbIQVfP+rtYd4xSt3pxKtZUkalGD37Q3+mer/hhS7pUgvGlEe+K3XZgk6R8iQIU/lfBG1Mr",
+	"iFBRlpgm0wpkKdfSuxs3A94q/lepUEB5BPbzBeNL0P1p71azqKcf1jzI4uJEWb+YsMkRfPkye4RMYIxC",
+	"YDQig0FwRBiw9nigKlnClHO9vVsLGwtcXjYuapc5QesIGcWQh+iHa6vrObVZaV4J4k6QGzWmNM50rUxF",
+	"XSZ85TMOoea9NG6YrlYIs0cJxjpQacdPryxEeEUh6egrJ4HfUSrisuueG8fkLn82Qb2XbJylN6ApP9pp",
+	"NQ++vOOi4DDxVMXjAMfL4wh+gUvKP6mDXjMVUPAuIUIeYeSvom/iMWWAV7nxXJ38XVDcw8kjqq2qWvGB",
+	"kNvleAOo6if84VMUtX3MWV5Vas6U+QIEyjQXIRp24A1OUX+RwApKxwgWG8MnzLmj1RTClIT0jUMqIhSj",
+	"r9zKlrCimc6JjAOFJXvFekWHfEOBVB2DgvcAqtH+2DLcBYXdIHCs3YcRp+s6FillS+OFl0rdnnJHMsVe",
+	"0Ua5XGmKgny9QGHzuzZKf2YWaelV+k9jwNFy1ECZtOEf0ItxhUsULc36M+RTkR+dhTZJlplcKyXzRS3Z",
+	"O725MTzsw6eqxKVRxLR2NJk34N0pbFqWmA2ACoRYINq67j+4gVea5AgZZcJa5l5Y9iBnXlJeu5SQjC8T",
+	"LDojJuF7LpU5tqa40wcdQsphgZXv7GnXS5bIUdh46giXR/gFcQoenGqi3bG/bvO6oDNKVkEzXqHJG91o",
+	"QuGRLnJpeaHQreJqbY8MsvGN9D5p1tWdAqh14B1tKgnfhgL37BagTZ98TuvAlB1uMBgdHWGOGNkiu1WD",
+	"ncx+J3v2YrTpaNDnxLL17st52gXWS2+NTts5Ros0TZBy26frNsocXKZ0l0ZeHl7gRVGVS5jTJcKn+YwE",
+	"RJfNVsTdaGJMzZDTjJEp+TiajO6196laGZXGzdHzEg30K710M0X+ieqhXtWat9xPJkNOrNaN+4cy5h4h",
+	"X6+p2FgpwzOQLJU9ij2YhFU30O5wcTOslTN/HHeGj7uOfXeH7XMmHE2jrIZAgeNbYyqyC1zXj7fOEH5n",
+	"oZKgLZSaJj+az12T3dcCf/QrWi8ZD74m2H07JbDtW6ym9VbZzjzoIMje26ruxK0PqjLDkMUsdDpXnZsi",
+	"C1iqwlXXSlsBXc3Qy4P/bAxYi1sY0Oi39wdmRLWPeeo29TTqGZjn7eOezvRsH/s4bfQJEeg+OLgi/zTH",
+	"aa0YjLfuwxoPDmoYfhyKh58JXZOFuvPEw5h7d9N6Brd7ucgx0ZeNrmjtFU7D5Qipz2fluSjntHuZqVrU",
+	"cVvr/lpRYYhFsbVupejaXGr8yFFsTP/0y/M/Hj5+/Pi3X6tHWOa7+hWW1DvsfYIVYUzzRJEpuZ/c33+Y",
+	"3H2Y3H2+m0zNf6PJ3eTfQ5f+rSZoF7TV/7su4M9QHnnkr/pfz1H9tBPW96hgb3oo4w4LVG+IHNRbClnK",
+	"9EflEOZg2igvz045Jq1XYddMGfXAv3Euxtv6baNPrqitPZJgBh5oXjlPuM8cDh3/d7ap84hkf3oo70h9",
+	"c8N1jLw44C+WFbgf5MfOffwhgBT3zj8JTnpe6+wju8JOiEW67gOSN9EVd78/BY6ar1hPo8+ehzR7eLQY",
+	"bphBZ58PDyNtvC2fYh/Bt5d2euD90/6H6le9ZKj8Wjh7CLI+pP7/4biB92t7M8QB5/mnjJ/ThVdijCt0",
+	"JYcDoUmjng8MQbqeaXRC0VetN2YDp/yJx0lI7b7n64JUrRDCXAhdvjjzhTJTWU8czEeuO1pwuMjfMrgv",
+	"BXe3SC2OK3SXtsLmS8Pdbve/AAAA//8S4DNZYDYAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/api/api.gen.go
+++ b/pkg/api/api.gen.go
@@ -172,8 +172,8 @@ type ImpactTypeIdPathParameter = Id
 // IncidentIdPathParameter Identification for objects. UUID preferred.
 type IncidentIdPathParameter = Id
 
-// IncidentUpdateIdPathParameter Positive and incrementing number for ordering and identfication of e.g. sub resources.
-type IncidentUpdateIdPathParameter = Incremental
+// IncidentUpdateOrderPathParameter Positive and incrementing number for ordering and identfication of e.g. sub resources.
+type IncidentUpdateOrderPathParameter = Incremental
 
 // ComponentListResponse defines model for ComponentListResponse.
 type ComponentListResponse struct {
@@ -185,10 +185,16 @@ type ComponentResponse struct {
 	Data *Component `json:"data,omitempty"`
 }
 
+// GenerationResponse defines model for GenerationResponse.
+type GenerationResponse struct {
+	// Generation Positive and incrementing number for ordering and identfication of e.g. sub resources.
+	Generation *Incremental `json:"generation,omitempty"`
+}
+
 // IdResponse defines model for IdResponse.
 type IdResponse struct {
-	// Data Identification for objects. UUID preferred.
-	Data *Id `json:"data,omitempty"`
+	// Id Identification for objects. UUID preferred.
+	Id *Id `json:"id,omitempty"`
 }
 
 // ImpactTypeListResponse defines model for ImpactTypeListResponse.
@@ -224,10 +230,10 @@ type IncidentUpdateResponse struct {
 	Data *IncidentUpdate `json:"data,omitempty"`
 }
 
-// IncrementalResponse defines model for IncrementalResponse.
-type IncrementalResponse struct {
-	// Data Positive and incrementing number for ordering and identfication of e.g. sub resources.
-	Data *Incremental `json:"data,omitempty"`
+// OrderResponse defines model for OrderResponse.
+type OrderResponse struct {
+	// Order Positive and incrementing number for ordering and identfication of e.g. sub resources.
+	Order *Incremental `json:"order,omitempty"`
 }
 
 // PhaseListResponse defines model for PhaseListResponse.
@@ -349,14 +355,14 @@ type ServerInterface interface {
 	// (POST /incidents/{incidentId}/updates)
 	CreateIncidentUpdate(ctx echo.Context, incidentId IncidentIdPathParameter) error
 	// Delete a specific update from a specific incident
-	// (DELETE /incidents/{incidentId}/updates/{updateId})
-	DeleteIncidentUpdate(ctx echo.Context, incidentId IncidentIdPathParameter, updateId IncidentUpdateIdPathParameter) error
+	// (DELETE /incidents/{incidentId}/updates/{updateOrder})
+	DeleteIncidentUpdate(ctx echo.Context, incidentId IncidentIdPathParameter, updateOrder IncidentUpdateOrderPathParameter) error
 	// Get a specific update from a specific incident.
-	// (GET /incidents/{incidentId}/updates/{updateId})
-	GetIncidentUpdate(ctx echo.Context, incidentId IncidentIdPathParameter, updateId IncidentUpdateIdPathParameter) error
+	// (GET /incidents/{incidentId}/updates/{updateOrder})
+	GetIncidentUpdate(ctx echo.Context, incidentId IncidentIdPathParameter, updateOrder IncidentUpdateOrderPathParameter) error
 	// Update a specific update from a specific incident.
-	// (PATCH /incidents/{incidentId}/updates/{updateId})
-	UpdateIncidentUpdate(ctx echo.Context, incidentId IncidentIdPathParameter, updateId IncidentUpdateIdPathParameter) error
+	// (PATCH /incidents/{incidentId}/updates/{updateOrder})
+	UpdateIncidentUpdate(ctx echo.Context, incidentId IncidentIdPathParameter, updateOrder IncidentUpdateOrderPathParameter) error
 	// Get the current generation list of phases.
 	// (GET /phases)
 	GetPhaseList(ctx echo.Context, params GetPhaseListParams) error
@@ -627,16 +633,16 @@ func (w *ServerInterfaceWrapper) DeleteIncidentUpdate(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter incidentId: %s", err))
 	}
 
-	// ------------- Path parameter "updateId" -------------
-	var updateId IncidentUpdateIdPathParameter
+	// ------------- Path parameter "updateOrder" -------------
+	var updateOrder IncidentUpdateOrderPathParameter
 
-	err = runtime.BindStyledParameterWithLocation("simple", false, "updateId", runtime.ParamLocationPath, ctx.Param("updateId"), &updateId)
+	err = runtime.BindStyledParameterWithLocation("simple", false, "updateOrder", runtime.ParamLocationPath, ctx.Param("updateOrder"), &updateOrder)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter updateId: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter updateOrder: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.DeleteIncidentUpdate(ctx, incidentId, updateId)
+	err = w.Handler.DeleteIncidentUpdate(ctx, incidentId, updateOrder)
 	return err
 }
 
@@ -651,16 +657,16 @@ func (w *ServerInterfaceWrapper) GetIncidentUpdate(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter incidentId: %s", err))
 	}
 
-	// ------------- Path parameter "updateId" -------------
-	var updateId IncidentUpdateIdPathParameter
+	// ------------- Path parameter "updateOrder" -------------
+	var updateOrder IncidentUpdateOrderPathParameter
 
-	err = runtime.BindStyledParameterWithLocation("simple", false, "updateId", runtime.ParamLocationPath, ctx.Param("updateId"), &updateId)
+	err = runtime.BindStyledParameterWithLocation("simple", false, "updateOrder", runtime.ParamLocationPath, ctx.Param("updateOrder"), &updateOrder)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter updateId: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter updateOrder: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.GetIncidentUpdate(ctx, incidentId, updateId)
+	err = w.Handler.GetIncidentUpdate(ctx, incidentId, updateOrder)
 	return err
 }
 
@@ -675,16 +681,16 @@ func (w *ServerInterfaceWrapper) UpdateIncidentUpdate(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter incidentId: %s", err))
 	}
 
-	// ------------- Path parameter "updateId" -------------
-	var updateId IncidentUpdateIdPathParameter
+	// ------------- Path parameter "updateOrder" -------------
+	var updateOrder IncidentUpdateOrderPathParameter
 
-	err = runtime.BindStyledParameterWithLocation("simple", false, "updateId", runtime.ParamLocationPath, ctx.Param("updateId"), &updateId)
+	err = runtime.BindStyledParameterWithLocation("simple", false, "updateOrder", runtime.ParamLocationPath, ctx.Param("updateOrder"), &updateOrder)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter updateId: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter updateOrder: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.UpdateIncidentUpdate(ctx, incidentId, updateId)
+	err = w.Handler.UpdateIncidentUpdate(ctx, incidentId, updateOrder)
 	return err
 }
 
@@ -760,9 +766,9 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.PATCH(baseURL+"/incidents/:incidentId", wrapper.UpdateIncident)
 	router.GET(baseURL+"/incidents/:incidentId/updates", wrapper.GetIncidentUpdates)
 	router.POST(baseURL+"/incidents/:incidentId/updates", wrapper.CreateIncidentUpdate)
-	router.DELETE(baseURL+"/incidents/:incidentId/updates/:updateId", wrapper.DeleteIncidentUpdate)
-	router.GET(baseURL+"/incidents/:incidentId/updates/:updateId", wrapper.GetIncidentUpdate)
-	router.PATCH(baseURL+"/incidents/:incidentId/updates/:updateId", wrapper.UpdateIncidentUpdate)
+	router.DELETE(baseURL+"/incidents/:incidentId/updates/:updateOrder", wrapper.DeleteIncidentUpdate)
+	router.GET(baseURL+"/incidents/:incidentId/updates/:updateOrder", wrapper.GetIncidentUpdate)
+	router.PATCH(baseURL+"/incidents/:incidentId/updates/:updateOrder", wrapper.UpdateIncidentUpdate)
 	router.GET(baseURL+"/phases", wrapper.GetPhaseList)
 	router.POST(baseURL+"/phases", wrapper.CreatePhaseList)
 
@@ -771,41 +777,42 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/9Rb64/buBH/VwZsgd4BiuzdHFDUQFHkdq8HA0Fum02+9JIPtDS2mcqUjqR2ayz8vxck",
-	"9aBeNuXXpkA+rCWKnMePv5nhMC8kSjdZypErSWYvJKOCblChML/uynfz+IGq9UP5Ur+LUUaCZYqlnMzq",
-	"kTC/ByZB4B85ExgD45BRtQ5JQJgeqH+QgHC6QTKrF5/HJCDlR2SmRI4BkdEaN1Qv9meBSzIjf5rU0k7s",
-	"WzmZx2S3C8ivyFFQLc6/chTbPbL+Zv6gCayqT7SYf+jPQvglXIXwj/rV3/9aim4G1LLXQ4i3qDwSuEGu",
-	"aGJknm8yGqlP2wwPGtgOBbXNcJyJmbPGqTae84jFPnAoB44UtZr+XIJ+zmKq0F/c3IwHFsMPjJeu+nGE",
-	"Cnmx4PEKNCCys9OgVD+nMcPmpvxo3+hnUcoVcvMnzbKERQaXk29Sq/fiuXQ1sV24aaJH5DFQqD4LSQO/",
-	"55alnnlYGA6s3hRWnsKPZ5emmHevLMWYhiAWf5cSx87uI1QBbCPbw5pKfM/k2a1UTbwHPxyfIWFSQbqE",
-	"TI+XIbEol1nKZQvhVkr7ZpSYmUgzFKrYMTFV/uAvFAiIRhWZkXTxDaNeld5BsTdBoMoFl0Ar3eoVjM2d",
-	"PXtdbY7XpLXT4ytJXhD4MSJzmN+3aOmKAGouejqCHG6THbK9skYnuGSIoq/pGWfJM/ilmE22Is5VVTnF",
-	"IcNx6hV8Ui98Ps8UwU72RuJX0O4MznLjt5MhXk+dRtlyJDnXs7TzkKto4aYnRyLNZCwGbzZrKaZu5Cxd",
-	"4ehyiZHC+OetH+NaGQMSM5kldPvBVBb7P7x3hu4CwmKfMBuQhC4wkYfGvrejymLE1jS/60W+duwYNJM3",
-	"PTVTuJEjEha9Co1/48m2rJyKNagQdKvf3+tN1SniHlLGlS7PFNtgCB/yJKGLBGGZCkgz5KAzUP1uqetA",
-	"qQu4ZSo2VJGZxg++0e90JVd82FpdKsH4yizvLvvSgU2S8hUKUPhfBc9MrSFGRVliSke7IEu5Xr07cdPh",
-	"rQR6nQoFlMdgny8YX4GuOnunmsc9Va5mErYs9pS1i3GbDOHz5/k9ZAKXKATGIRl0grOEAWuPBaqgH6Wc",
-	"6+ndbNJo4DKbMVE7UQhaW8gIhjxCP1xbWU/Jbkr1ShB3nNzI0qQxpqtlKupA+4XPOUSaOdJlQ3W1Rpjf",
-	"SzDagUo7dnpiEcITCknDL5wEflup8Muuu28clbsM2gT1XrJxhl6Bpvxop5V++/KOi4LDxFOlXwMcL8cR",
-	"/AJXlL9TB61mcojgVVyEPMbYX0TfwGMCqVfA/ljt/F1QnK7JEflKFe99IOTWCd4AqjJyf/gUaWEfc5YH",
-	"kJozZb4AgTLNRYSGHXiDU9RfJLCC0jGGxdbwCXNOXjWFMCUhfeaQihhF+IXbtSWsaaZjIuNAYcWesB7R",
-	"Id9IIFVjUPAaQDXSj01kXVDYCQJH230YceqWsUgpiwIvvFTi9qQ7kin2hNbL5UiTFOSbBQob37VS+pkZ",
-	"pFevwn+6BAxXYQNl0rp/QC7GFa5QtCTrj5Dvi/joDLRBsozkWiiZL+qVvcOb68PDNnxfpbg0jplt/Dw0",
-	"4N1JbFqamAmACoSlQLR53X9wC080yREyyoTVzD3y60HOQ0l57VRCMr5KsKgtmIRvuVRm25rkTm90iCiH",
-	"BVa2s7tdD3E6WNrD5RZ+RJyBB6cab3f0rwulLuiMkJXTjFVo8ky3mlB4rJNcWpbk3SzO6ZiNc7I9Kfbe",
-	"adbUnQSoteEb/btiha9DjvvoJqBNm3xKa8eUNWIw6B3tYY4Y2yS7lYMdzX5HW/ZstOlI8LW3utbFj9lu",
-	"TOnaijzePcKjoiqX8EBXCO8e5iQgOtm1Zr0Jp0bADDnNGJmRt+E0vNU2o2ptzDVptq5XaACrDWrk0CUQ",
-	"+RXVXT2q1We4nU6HVK/GTfqbEab6zzcbKrZ2leGz/yyVPYLdmTBTl71uo287LJXTC5x0GoG7jn43h/Vz",
-	"TvabSlkJi56N2w3YBa7pJy9OE39nt0eCNr1pqnxvnrsqu7cNfu8XtB4yGbyNsPvaUfynngI6jyKUcpkn",
-	"IXxI4a44aWoqbWXstD8OYuuiyoxB6V6EygwjtmSRU2bqQBJbnFIVrbta2nTlYoqeH/PHut4q2nK9xrqt",
-	"8U0jZh/P1KXkcUQz0LXaxzSdHtE+rnFK3SMM3231X5Btmk2jlg8mL+6VFg/GaSg+DrzDF3QuwDndZtlh",
-	"qF1Wo1Go9WMeR0Vf7rmgthfYBCfTT5+pyl1Q9h738lA1qGOtlliKCkMjim10cUM35pjBXHMzFc0PH/95",
-	"9/bt27/9GA5cgZN6hr1XnWJc0jxRZEZup7e3b6Y3b6Y3n26mM/MvnN5M/z10DN8qS3ZBW/xfdEp9gvDI",
-	"Y3/RfzpF9OM2Vl+jfG8wKP0OC1TPiBzUcwpZyvSjsi1yMEiUx1nH7I7W7atLBoi6id3YF5OX+g6hT2So",
-	"tR3JKwMXIS8TFdyO/aFdf0lVRqDWMxiUh5W+keAySp4d56fGAO4H8IlzHn4IF8W573cCj577JvuordAT",
-	"liLd9OHHm9aKs9fvAj7Nu6HHkWXPVZA9rFk0F0yjsc+Gh5E2eSkvOI9g13MbPfD+tP/69yWOCypzFjYe",
-	"QqoPhf8f2Gv0VveLBweM5x8gvk8TXogozldxHLa/poj6NH4IyXUHYawHBv8Xz3Eg7N4x6+JPrRGiXAid",
-	"hzgn9p1b6vsjjKvyaE93ruRfIxo4uuoyao2t62273f8CAAD//x09KakdNgAA",
+	"H4sIAAAAAAAC/9RbW4/buBX+KwRboLuAInsmCxQ1UBTZme3CQJC4meSlmzzQ0pHNVKYUkpqpYfi/FyR1",
+	"oa6m5EtSYB5mJIrn9p0bD+eAg2SXJgyYFHhxwCnhZAcSuP7roXi3DFdEblfFS/UuBBFwmkqaMLyoVqLl",
+	"I6ICcfiWUQ4hogylRG597GGqFqo/sIcZ2QFeVMSXIfZw8RFeSJ6Bh0WwhR1RxP7MIcIL/KdZxe3MvBWz",
+	"ZYiPRw//Dgw4Uez8KwO+H+D1vf6FxGhTfqLY/KY+89Fv/sZH/6he/f2vBet6QcV7tQQ7s8oCDjtgksSa",
+	"5+UuJYH8uE/hpILNUiT3KYxTMbVonKvjJQto6AKHYuFIVsvtL8XopzQkEt7zELgrx5n+BCXqG/QTZYXB",
+	"fh4hSFaRnS5JDStHsw0I+WsSUqh75wfzRj0LEiaB6V9JmsY00ACdfRVKyIMj6XJjQ7iuqCdgISKo/MzH",
+	"NSBfmpdq535mGKKVdxh+cmtenJt830Fe8jU1RgwQr8WO2d2FqRzemrfVlgh4S8XFtVRuPIAfBi8opkKi",
+	"JEKpWi98bFAu0oSJBsINl+bNKDZTnqTAZe4xIZHu4M8F8LBCFV7gZP0Vgk6R3qDcNxEHmXEmECllqyho",
+	"nVs+e1tppktS9/QqzV5AAiuFjsyckySpyBnfDC8gAg0dU9IUjhlaPjbi6w09oU70fFewgrRoZY0bS3SG",
+	"SfpyzS0tY5G8gF3y3UQjdd5UlHMM0p9wv4NNKsKXs0yetUVnSfEdpLuAsexCRBfKFxBE1+y3yCTMtAfN",
+	"KuomlrCLq4nw0vWWBpmpufKtaxVXmzkSRRBICH/du4VZw6OHQyrSmOzf6dZo+MNHa+nRc8ytHo7JGmJx",
+	"au1bs6popUxH9oci8qWlR69eeupEL2EnRpRbigoJ37N4X/R9OQ3COdmr94/Kk1qN6CqhTKr+UtId+Ohd",
+	"FsdkHQOKEo6SFBhS9bN6F6leVqgONEr4jki8UPiBV+qdakXzDxvUheSUbTR5m+yhBZs4YRvgSMJ/JXqh",
+	"cotCkITGuvc1BHUd1bVx3eCN8n+bcIkIC5F5vqZsg1Tb3LnVMuzo1FX4oFHuU0Yv2mzCR58+LR9RyiEC",
+	"ziH0ca8RLBIarB0aKDN9kDCmtrdrYS2BHc60iprVgddwIc0YsADccG14PaekKcQrQNwycq00E1qZtpQJ",
+	"r7LrZ7ZkKFCRI4lqosstoOWjQFo6JJOWnp5pAOgZuCD+Z4Y9N1fK7XJs+40lcjuC1kE9GGyspTcIU25h",
+	"p1Fzu8YdGwWnA09Zc/XEeDEuwK9hQ9gbeVJrunDwvouJgIUQurPomnh0InVK2B9Kzz96+fGgGFGplPne",
+	"BUJ2c+AMoLIMd4dPXgt2Rc78EJWqmCmyNeIgkowHoKMDq8UU+ReBaB7SIUTrvY4n1DpAViGESoGSl6Lu",
+	"+swMbYG2JFU5kTLV3tNnqFa0gm/AgcgxKPgeQJ1UwtqgSPJD50raIYxYzcpYpBSdgBNeSnY7yh1BJX0G",
+	"Y+VipS4Kst0auMnvSij1TC9S1Mv0n0QI/I1fQ5kw5u/hizIJG+ANzroz5Ns8P1oLTZIsMrliSmTrirJz",
+	"erNteFqHb8sSl4QhNfOrVQ3ercKmIYneABEOKOIApq77D+zRM4kzQCmh3EhmH1h2IGdVhLxmKSEo28SQ",
+	"9xZUoK+ZkNptdXGnHB0FhKE1lLoz3q6WWIM4ZeHChZ8AFsghpmprt+SvGqU26DSTpdG0Vkj8QvYqoLBQ",
+	"Fbmk6MPbVdzEU8s8XQhnTzOqbhVADYevjSFzCl/6DPfBLkDrOvmYVIYpekSv1zrKwgwgNEV2owabHP0m",
+	"a/ZiYdPi4Etnd62aH+1uVKreCj89PKEnSWQm0IpsAL1ZLbGHVbFr1HrnzzWDKTCSUrzAr/25f690RuRW",
+	"q2tWn8BvQANWKVTzoVog/DvIh2pVY0pyP5/3iV6um3WPUnT3n+12hO8Nlf7JRZqIDsYedJqp2l57TLnv",
+	"58qaZM5aY8xjS7670/JZh/l1oQyH+cTJnmUcPVv1s4N1F+Fo3CMGU97URX7Uz22R7UsTf3QzWi2Z9V6q",
+	"OH5pCf5LRwOdBQEIEWWxj94l6CE/aaoLbXhsDW9OYuuqwoxB6SBCRQoBjWhgtZkqkYQGp0QG27aUply5",
+	"mqCXx/xU0xtBG6ZXWDc9vp6+DMWZqpWcFmh6RlVDkaY1GBqKNVarO0Hx7YsKV4w29UlRwwazg30zxyHi",
+	"1AQfB97+e0ZXiDntCdlpqF1XolGodYs8loiuseeK0l7BCc4OP12qKrygGDgOxqFyUUtbDbYk4TqMSLpT",
+	"zQ3Z6WMGfVtPdzQ/ffjnw+vXr//2s99zk0+oHQYvaoUQkSyWeIHv5/f3r+Z3r+Z3H+/mC/3jz+/m/+47",
+	"hm+0JUevyf5vqqQ+g3lgoTvrv5zD+jTH6pqODyaDwu5oDfIFgCH5kqA0oepRMRY5mSSK46wp3tG4O3bN",
+	"BFFNrmt+MTtUVyFdMkMl7ci40nOf8zpZwR7Tn/L6a4oyArWOyaA4rHTNBNcR8uI4PzcHMDeAz6zz8FO4",
+	"yM99fxB4dFwyGQptuZwo4smuCz/OYS0/e/0h4FO/2TopWNbvfwzEy3ysoEeMXdo7jbHZwbqbPSK0Xlrj",
+	"nvOnvVfYr3FcUCo113QfUl1C+P+HykZ7u1tKOKE/9xzxw2rxSuHicn3HaROocFGdyffhuZojjDVC778k",
+	"TcNh+6ZZG4JyCyjIOFfViHVu37ppP5xnbJFHW7r1bwWTckLHPfOBxGCJqnqpLTTuuB2P/wsAAP//JnBH",
+	"Zuk2AAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/api/api.gen.go
+++ b/pkg/api/api.gen.go
@@ -28,15 +28,9 @@ type Component struct {
 	// DisplayName Short and describing name.
 	DisplayName *DisplayName `json:"displayName,omitempty"`
 
-	// Id Identification for objects. UUID preferred.
-	Id *Id `json:"id,omitempty"`
-
 	// Labels Labels are free text key value pairs for components.
 	Labels *Labels `json:"labels,omitempty"`
 }
-
-// ComponentList defines model for ComponentList.
-type ComponentList = []Component
 
 // Date Point in time. Nullable for open end timeframes.
 type Date = time.Time
@@ -47,8 +41,20 @@ type Description = string
 // DisplayName Short and describing name.
 type DisplayName = string
 
+// Generation Incremental as generation field for responses.
+type Generation struct {
+	// Generation Positive and incrementing number for ordering and identfication of e.g. sub resources.
+	Generation Incremental `json:"generation"`
+}
+
 // Id Identification for objects. UUID preferred.
 type Id = string
+
+// IdField Id field for responses.
+type IdField struct {
+	// Id Identification for objects. UUID preferred.
+	Id Id `json:"id"`
+}
 
 // Impact An impact connects a component and an incident with an impact type.
 type Impact struct {
@@ -74,13 +80,7 @@ type ImpactType struct {
 
 	// DisplayName Short and describing name.
 	DisplayName *DisplayName `json:"displayName,omitempty"`
-
-	// Id Identification for objects. UUID preferred.
-	Id *Id `json:"id,omitempty"`
 }
-
-// ImpactTypeList defines model for ImpactTypeList.
-type ImpactTypeList = []ImpactType
 
 // Incident defines model for Incident.
 type Incident struct {
@@ -100,18 +100,12 @@ type Incident struct {
 	// EndedAt Point in time. Nullable for open end timeframes.
 	EndedAt *Date `json:"endedAt"`
 
-	// Id Identification for objects. UUID preferred.
-	Id Id `json:"id"`
-
 	// Phase To reference a phase, its generation and order is needed.
 	Phase *PhaseReference `json:"phase,omitempty"`
 
 	// Updates List of Incrementals for referencing subresources.
 	Updates *IncrementalList `json:"updates,omitempty"`
 }
-
-// IncidentList defines model for IncidentList.
-type IncidentList = []Incident
 
 // IncidentUpdate An update is a sub resource to an incident.
 // It's identified by the incident ID and its own order.
@@ -125,13 +119,7 @@ type IncidentUpdate struct {
 
 	// DisplayName Short and describing name.
 	DisplayName *DisplayName `json:"displayName,omitempty"`
-
-	// Order Positive and incrementing number for ordering and identfication of e.g. sub resources.
-	Order Incremental `json:"order"`
 }
-
-// IncidentUpdateList defines model for IncidentUpdateList.
-type IncidentUpdateList = []IncidentUpdate
 
 // Incremental Positive and incrementing number for ordering and identfication of e.g. sub resources.
 type Incremental = int
@@ -142,6 +130,12 @@ type IncrementalList = []Incremental
 // Labels Labels are free text key value pairs for components.
 type Labels map[string]string
 
+// Order Incremental as order field for responses.
+type Order struct {
+	// Order Positive and incrementing number for ordering and identfication of e.g. sub resources.
+	Order Incremental `json:"order"`
+}
+
 // Phase A single phase is just its name.
 // It can be referenced by its generation and order.
 // See: #/components/schemas/PhaseReference
@@ -149,16 +143,11 @@ type Phase = string
 
 // PhaseList Phase resources are always handled as a list.
 type PhaseList struct {
-	// Generation Positive and incrementing number for ordering and identfication of e.g. sub resources.
-	Generation *Incremental `json:"generation,omitempty"`
-	Phases     []Phase      `json:"phases"`
+	Phases []Phase `json:"phases"`
 }
 
-// PhaseReference To reference a phase, its generation and order is needed.
+// PhaseReference defines model for PhaseReference.
 type PhaseReference struct {
-	// DisplayName Short and describing name.
-	DisplayName *DisplayName `json:"displayName,omitempty"`
-
 	// Generation Positive and incrementing number for ordering and identfication of e.g. sub resources.
 	Generation Incremental `json:"generation"`
 
@@ -183,69 +172,178 @@ type IncidentUpdateOrderPathParameter = Incremental
 
 // ComponentListResponse defines model for ComponentListResponse.
 type ComponentListResponse struct {
-	Data *ComponentList `json:"data,omitempty"`
+	Data *[]struct {
+		// ActivelyAffectedBy A list of impacts for an component.
+		// Impacts reference incidents.
+		ActivelyAffectedBy *ImpactIncidentList `json:"activelyAffectedBy,omitempty"`
+
+		// DisplayName Short and describing name.
+		DisplayName *DisplayName `json:"displayName,omitempty"`
+
+		// Id Identification for objects. UUID preferred.
+		Id Id `json:"id"`
+
+		// Labels Labels are free text key value pairs for components.
+		Labels *Labels `json:"labels,omitempty"`
+	} `json:"data,omitempty"`
 }
 
 // ComponentResponse defines model for ComponentResponse.
 type ComponentResponse struct {
-	Data *Component `json:"data,omitempty"`
+	Data *struct {
+		// ActivelyAffectedBy A list of impacts for an component.
+		// Impacts reference incidents.
+		ActivelyAffectedBy *ImpactIncidentList `json:"activelyAffectedBy,omitempty"`
+
+		// DisplayName Short and describing name.
+		DisplayName *DisplayName `json:"displayName,omitempty"`
+
+		// Id Identification for objects. UUID preferred.
+		Id Id `json:"id"`
+
+		// Labels Labels are free text key value pairs for components.
+		Labels *Labels `json:"labels,omitempty"`
+	} `json:"data,omitempty"`
 }
 
-// GenerationResponse defines model for GenerationResponse.
-type GenerationResponse struct {
-	// Generation Positive and incrementing number for ordering and identfication of e.g. sub resources.
-	Generation *Incremental `json:"generation,omitempty"`
-}
+// GenerationResponse Incremental as generation field for responses.
+type GenerationResponse = Generation
 
-// IdResponse defines model for IdResponse.
-type IdResponse struct {
-	// Id Identification for objects. UUID preferred.
-	Id *Id `json:"id,omitempty"`
-}
+// IdResponse Id field for responses.
+type IdResponse = IdField
 
 // ImpactTypeListResponse defines model for ImpactTypeListResponse.
 type ImpactTypeListResponse struct {
-	Data *ImpactTypeList `json:"data,omitempty"`
+	Data *[]struct {
+		// Description A longer text with detailed information.
+		Description *Description `json:"description,omitempty"`
+
+		// DisplayName Short and describing name.
+		DisplayName *DisplayName `json:"displayName,omitempty"`
+
+		// Id Identification for objects. UUID preferred.
+		Id Id `json:"id"`
+	} `json:"data,omitempty"`
 }
 
 // ImpactTypeResponse defines model for ImpactTypeResponse.
 type ImpactTypeResponse struct {
-	Data *ImpactType `json:"data,omitempty"`
+	Data *struct {
+		// Description A longer text with detailed information.
+		Description *Description `json:"description,omitempty"`
+
+		// DisplayName Short and describing name.
+		DisplayName *DisplayName `json:"displayName,omitempty"`
+
+		// Id Identification for objects. UUID preferred.
+		Id Id `json:"id"`
+	} `json:"data,omitempty"`
 }
 
 // IncidentListResponse defines model for IncidentListResponse.
 type IncidentListResponse struct {
-	Data *IncidentList `json:"data,omitempty"`
+	Data *[]struct {
+		// Affects A list of impacts for an incident.
+		// Impacts reference components.
+		Affects *ImpactComponentList `json:"affects,omitempty"`
+
+		// BeganAt Point in time. Nullable for open end timeframes.
+		BeganAt *Date `json:"beganAt"`
+
+		// Description A longer text with detailed information.
+		Description *Description `json:"description,omitempty"`
+
+		// DisplayName Short and describing name.
+		DisplayName *DisplayName `json:"displayName,omitempty"`
+
+		// EndedAt Point in time. Nullable for open end timeframes.
+		EndedAt *Date `json:"endedAt"`
+
+		// Id Identification for objects. UUID preferred.
+		Id Id `json:"id"`
+
+		// Phase To reference a phase, its generation and order is needed.
+		Phase *PhaseReference `json:"phase,omitempty"`
+
+		// Updates List of Incrementals for referencing subresources.
+		Updates *IncrementalList `json:"updates,omitempty"`
+	} `json:"data,omitempty"`
 }
 
 // IncidentResponse defines model for IncidentResponse.
 type IncidentResponse struct {
-	Data *Incident `json:"data,omitempty"`
+	Data *struct {
+		// Affects A list of impacts for an incident.
+		// Impacts reference components.
+		Affects *ImpactComponentList `json:"affects,omitempty"`
+
+		// BeganAt Point in time. Nullable for open end timeframes.
+		BeganAt *Date `json:"beganAt"`
+
+		// Description A longer text with detailed information.
+		Description *Description `json:"description,omitempty"`
+
+		// DisplayName Short and describing name.
+		DisplayName *DisplayName `json:"displayName,omitempty"`
+
+		// EndedAt Point in time. Nullable for open end timeframes.
+		EndedAt *Date `json:"endedAt"`
+
+		// Id Identification for objects. UUID preferred.
+		Id Id `json:"id"`
+
+		// Phase To reference a phase, its generation and order is needed.
+		Phase *PhaseReference `json:"phase,omitempty"`
+
+		// Updates List of Incrementals for referencing subresources.
+		Updates *IncrementalList `json:"updates,omitempty"`
+	} `json:"data,omitempty"`
 }
 
 // IncidentUpdateListResponse defines model for IncidentUpdateListResponse.
 type IncidentUpdateListResponse struct {
-	Data *IncidentUpdateList `json:"data,omitempty"`
+	Data *[]struct {
+		// CreatedAt Point in time. Nullable for open end timeframes.
+		CreatedAt *Date `json:"createdAt"`
+
+		// Description A longer text with detailed information.
+		Description *Description `json:"description,omitempty"`
+
+		// DisplayName Short and describing name.
+		DisplayName *DisplayName `json:"displayName,omitempty"`
+
+		// Order Positive and incrementing number for ordering and identfication of e.g. sub resources.
+		Order Incremental `json:"order"`
+	} `json:"data,omitempty"`
 }
 
 // IncidentUpdateResponse defines model for IncidentUpdateResponse.
 type IncidentUpdateResponse struct {
-	// Data An update is a sub resource to an incident.
-	// It's identified by the incident ID and its own order.
-	// Updates happen in a given order.
-	Data *IncidentUpdate `json:"data,omitempty"`
+	Data *struct {
+		// CreatedAt Point in time. Nullable for open end timeframes.
+		CreatedAt *Date `json:"createdAt"`
+
+		// Description A longer text with detailed information.
+		Description *Description `json:"description,omitempty"`
+
+		// DisplayName Short and describing name.
+		DisplayName *DisplayName `json:"displayName,omitempty"`
+
+		// Order Positive and incrementing number for ordering and identfication of e.g. sub resources.
+		Order Incremental `json:"order"`
+	} `json:"data,omitempty"`
 }
 
-// OrderResponse defines model for OrderResponse.
-type OrderResponse struct {
-	// Order Positive and incrementing number for ordering and identfication of e.g. sub resources.
-	Order *Incremental `json:"order,omitempty"`
-}
+// OrderResponse Incremental as order field for responses.
+type OrderResponse = Order
 
 // PhaseListResponse defines model for PhaseListResponse.
 type PhaseListResponse struct {
-	// Data Phase resources are always handled as a list.
-	Data *PhaseList `json:"data,omitempty"`
+	Data *struct {
+		// Generation Positive and incrementing number for ordering and identfication of e.g. sub resources.
+		Generation Incremental `json:"generation"`
+		Phases     []Phase     `json:"phases"`
+	} `json:"data,omitempty"`
 }
 
 // ComponentRequest defines model for ComponentRequest.
@@ -783,41 +881,42 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/9RbW2/cuBX+KwRboLuAohk7CxQdoCiy9nYxQJC4cfLSTR440pkZphpKIam4A2P+e8GL",
-	"JOo6lObiFPCDLVHkuXznnO+Q9DOO0l2WMmBS4MUzzggnO5DA9V93xbtl/EDk9qF4qd7FICJOM0lThhfV",
-	"SLS8R1QgDt9yyiFGlKGMyG2IA0zVQPUHDjAjO8CLavFljANcfIQXkucQYBFtYUfUYn/msMYL/KdZJe3M",
-	"vBWzZYwPhwD/Dgw4UeL8Kwe+H5D1vf6FJGhTfqLE/KY+C9Fv4SZE/6he/f2vheh6QCV7NQR7i8oiDjtg",
-	"kiRa5uUuI5H8uM/gqIHNUCT3GYwzMXXWONXGSxbR2AcOxcCRopbTn0vQT1lMJLznMXBfiXP9CUrVN+gn",
-	"ygqH/TxCkbxadromNawczDQg5K9pTKEenR/MG/UsSpkEpn8lWZbQSAN09lUoJZ89ly4nNgvXDfUILEYE",
-	"lZ+FuAbkc8tSzdwvDEO0ig4jj/Xm2aWx8w7KYsfUBDFAvJQ4ZnYfoSy8tWwPWyLgLRVnt1I58QB+GDyh",
-	"hAqJ0jXK1HgRYoNykaVMNBBupDRvRomZ8TQDLm3ExET6g98qEGCFKrzA6eorRJ0qvUE2NhEHmXMmECl1",
-	"q1bQNndi9rraTNekHulVmT2DBk4JHVk5J2lSLWdiMz6DCjT2LElTJGZoed/Ir1eMhPqip4eCk6RFq2pc",
-	"WaMTXNJXa67pGWfJM/jFziYapfOqqpzikP6C+wI+qRY+n2ds1RadlOIFtDuDs1wioonyGRTRnP0alYSZ",
-	"9qDJoq7iCZdcTYSX5lsaZIZz2alrjKstHIkk/Q7J/s16DZGE+Ne9X7qtJ6sAx1RkCdm/063S8AT3ztBD",
-	"4FlrA5yQFSTi2Ni3ZlSHFYM68dRlXsJOjCBbisiS+D1L9kXXZ9cgnJO9en+v4qjVhj6klEnVXUq6gxC9",
-	"y5OErBJA65SjNAOGFHtW79aqkxWq/1ynfEckXij0wCv1TjWi9sPG6kJyyjZ6eXfZ5xZokpRtgCMJ/5Xo",
-	"icotikESmujO1yyoWVTXxHX3Nsj/NuUSERYj83xF2QapprlzqmXc0acrKNG1jShjF+02EaJPn5b3KOOw",
-	"Bs4h7p5SQ7JD47KuRyljajqX+WqJ3eSlTdLkAkEjYLQgwCLwQ62RdQqXLNRqobbl1RoTE9p6bgH9zJb2",
-	"TSm728B8ZjjwiwRr5kMb9h05wV/QqhXpkrTiMVMEPRavDnds5+16MA2mNGfoFZJhP1hKXu+b3Vzy7GGu",
-	"gte164iuH57LNbrxAK9gQ9gbedRYmqUEL+IZYDHE/iL6VjVdtb3YwYcy8RwCuxcpRtCiklxUG5d/KCm/",
-	"dGGpEch+SCo5vz+OLPHsStx2x5aqlC3yFeIg0pxHgGTazG7yLwJRW0EgRqs9ktsqcaDlvc70VAqUPhUk",
-	"7zMzawu0JZkqwZQhgjb0O1QjWrk/4kDkGBS8BFAn8WUXFGaCIVw43dBYdBSthhdGShE7GJWgirgazxYj",
-	"Ne/IdyvghkIoRdQzPUitXjKMdI0g3IQ1ZNkKY+WgTMIGeEOS7tL21hY2Z6CpbkUZU0KIfFWt5F3JXD8d",
-	"t9nbkiOTOKbmQOyhBuEWd2pooidAhANacwBDFf8De/SdJDmgjFBuNHN3QDuQ8lCktSYHEJRtErDNChXo",
-	"ay6kDk3NF1Uwo4gwtIKKAuiIVkOckz3l0SJMHwEWyCNvut6t9K86rzbItJCl07RVSPJE9ippsFjxZlI0",
-	"9m2iOHEb1JYE4R1ZxtQtUtYIajvplz5ffXBpbd0MH1OHjtk+M+h1iHIqA4gNVW8wqslJbbIxz5QNaxJ8",
-	"6ezQVQulI4xK1aHhx7tH9CiJzAV6IBtAbx6WOMDfgQtj1ptwrgXMgJGM4gV+Hc7DW2UzIrfaXLP6Kf4G",
-	"NEaVQbUcqpHCv0PFpgRunLTczud9qpfjZt3HMXoHId/tCN+bVfpPP7JUdAh2p2tl1Ty7R537fqmc09BZ",
-	"6yj00NLv5rh+zoFAXSkjoT21cs9DDoFr+tmzc5/hYMIjAcNa6irf6+euyu7Fiz+6Ba2GzHovZhy+tBT/",
-	"paMNz6MIhFjnSYjepejO7lbVlTYytg6AjmLrosqMQekgQkUGEV3TyGnyVe2IDU6JjLZtLQ0juZii58f8",
-	"VNcbRRuuV1g3/bg+wRnKM1WrOC3R9Bx3DWWa1uHSUK5xWtkJhm9fdrhgtqmfNjV8MHt2b/d4ZJya4uPA",
-	"239X6QI5p33Kdhxql9VoFGr9Mo+jom/uuaC2FwiCk9NPl6mKKCg2+wbzUDmoZa2GWJJwnUYk3al+huz0",
-	"7oG+8aebmJ8+/PPu9evXf/s57LkNKNQMg5e9YliTPJF4gW/nt7ev5jev5jcfb+YL/RPOb+b/7tvMb3Qi",
-	"h6Ap/m+KUp8gPLDYX/RfThF9WmB1nbAPFoPC72gF8gmAIfmUoiyl6lFxuHK0SBS7VFOio3H/7JIFojr9",
-	"rsXF7Lm6TulTGSptR+aVnjuhl6kK7lH/sai/pCojUOtZDIo9SN9KcBklz47zU2sA8wP4zNnmPoYLu537",
-	"g8Cj46LKUGqzeqI1T3dd+PFOa3Z79YeAT/127KRkWb9DMpAv7WmBTHusdxxjs2fnfveI1Hpuiwfen/Ze",
-	"g7/EdkFpVGvpPqT6pPD/D5ONjna/knDEfv414oe14oXSxfn6juMuUOmi2obvw3N1dDDWCb3/1jQNh+3b",
-	"am0Iyi2gKOdcsRFn3751W3+4zrgqj/Z0618TJtWEjrvqA4XBUVX1Ulto3JM7HP4XAAD//2AYIn0tNwAA",
+	"H4sIAAAAAAAC/9RbW4/buBX+KwRboLuAYnsmCxQ1UBTZmd2FgSCZZpKXbvaBlo5tphKlJalMjYH/e8GL",
+	"ROpOe+zJBMhDRqLI7xx+50r6Ecd5VuQMmBR4+YgLwkkGErj+66Z6t0ruiNzdVS/VuwREzGkhac7w0o1E",
+	"q1tEBeLwZ0k5JIgyVBC5m+EIUzVQ/YEjzEgGeOkWXyU4wtVHeCl5CREW8Q4yohb7K4cNXuK/zB3auXkr",
+	"5qsEHw4R/g0YcKLg/LsEvh/B+l7/h6RoW3+iYP6pPpuhX2bbGfqXe/XPv1fQ9QCH3Q3BwVBZzCEDJkmq",
+	"Ma+ygsTy476ASQWboUjuCzhOxdRb46k6XrGYJiF0qAYeCbWe/lxAPxUJkfCeJ8BDEZf6E5Srb9APlFUb",
+	"9uMRgpRu2dMlaXDlYKYBIX/OEwpN6/xg3qhncc4kMP1fUhQpjTVB51+EEvIxcOl6YrNwU1H3wBJEUP3Z",
+	"DDeIfG4sbuZhMAxRZx0Gj93Ns6Ox845isWMaQAwRLwXHzB4CytJbY7vbEQFvqTi7luqJR/jD4AGlVEiU",
+	"b1ChxosZNiwXRc5Ei+EGpXlzFMyC5wVwaS0mIVI/pRIy/YCk6fsNXv4+5VR+pZAm+BAF280fEVZkxEuc",
+	"r79ALJW+7QPCOdlrWVsjurp6g6zRIw6y5EwgUivNra8303MGZ1PT5bRzsvRNt+Ni/klSj6F1U4dCc/mA",
+	"sfzk7JhqTQcBYmh123LO34cZ+S7/8nbkhQ7RiWUv1JQaGjpVA8NR8zuhSR2Ln4Ekdi3Ryi5eKj+cap7A",
+	"juE85tsSxOTVoTqocqPnI4nNsURvAvjMjDlRV09njZ9oahBnj4ZWtEBcup5rp73PvBl+ThEFp9CnJ0s6",
+	"r9b0NLm1nbyRWXdlIrGkXyHdv9lsIJaQ/LwPq9H86KH0nFBRpGT/TpfE4xPcekMPEU7JGlIx9dFbM6pH",
+	"OxG+VTTu1Ph3OWVSle6SZjBD78o0JesU0CbnKC+AIVWaqHcbTjJlvxHe5DwjEi/VTsMr9U5V+fbDqqC3",
+	"ywvJKdvq5f1lHzs7leZsCxxJ+J9ED1TuUAKS0FS3FcyCOonsm7ip01Zltcu5RIQlyDxfU7ZFjGTQO5VH",
+	"xr5mSNV7QET4fbKNij9aYXWhpmZvMmjbmPqYhphrlfzuz9Lnu1dJD27FP7qx1mv2VX8gZujTp9UtKjhs",
+	"gHNIelVShdeeecMEp0lgf8qXkyb98mmj6qFPnbfFOWNKNr8s0tvvu2HNr3au18attQIshhD4FdYgQQfE",
+	"ahT2vSbSyM6FVryfk3xmK/umxu5XxJ8ZjlxaMe27uslAhbTh1cKBujq1D6lLJ08ByoEk71m6b7mfFvCP",
+	"dpNaAavpmUadsjf0Ce68lwRVftoNPjroBCqjyaJDhNewJeyNnMSnk5zoGygjwsASSMIh6hAe1G/7UNvw",
+	"IbINaHGE+7XtujDX1EwX+1yU7aJT5ZxEuVZOMy95DEjmbTuWfxOIWscNCVrvkdw5E0GrW+3TqBQof6jy",
+	"uM/MrC3QjhQqclOGCNrSr+BGdLxczIHIY5T/TYzF178WZWgL6sDZk+cIqnI4o7hqpM4GymwN3ARGNbd6",
+	"pgcpVddxM98gmG1njY2zrsoCoUzCVhcWuM2hDpq31kN6A4UNpIaxCoQo126lYJfoZw/TfvFtnVaSJKHm",
+	"DPCuwZBORtCSRE+ACAe04QAmgfsv7NFXkpaACkK5kczvzfZsnqlcprIucwIVlHfk1YSn5lrDRLurHFA7",
+	"8AnKtinYGoMK9KUUUlupzjiVXaOYMLQGF/e0cashXkKp2FdZ7D3AEgV4OJ+Jbq9cydQ1CA2yJpjeQZI+",
+	"kL3yHyxRmTepKvmuds3xRKNRMemNe7sLvsbtpIMq/+CnZOes9f0i9I82wz/mXpZiC8hocMvUtjOApJFO",
+	"+yWqKme0XVGpqiV8f3OP7iWRpUB3ZAvozd0KR/grcGGWv5otlAJULUYKipf49Wwxu1YbQuROK37evK6w",
+	"Bb3barc0NlUU4N/AZQYCt46UrheLoQ2sx837z510CV1mGeF7s8rwaUyRix5gNzoAudLbP9PdD6Pyjn3n",
+	"nTPfQ0e+q2n5vLOJplAGoT2e889aDpGv+vmjd3HjYOwtBZMKNEW+1c99kf0bJgOEdkPmgzdQFHdbgv/U",
+	"UxKXcQxCbMp0ht7l6MZ2eZpCG4ydw6VJbl1UmGNYOspQUUCsSmKvRlReODE8JTLedaU0ydXFBD0/50/d",
+	"eiNoa+sV1005pw+FxvyMK7VOczQDR3NjnqZzXjXma7xS8ATFd291XNDbNA+jWnswf/SvMQV4nIbgx5F3",
+	"+FLWBXxO9xBummqXlego1oZ5Hk/EUN9zQWkvYARPdj99qqqsoOoVjfqhelBHWy1YknDtRiTNVBVDMl2S",
+	"66uNusr44cOvN69fv/7Hj7OBa49CzTB6qy2BDSlTiZf4enF9/Wpx9Wpx9fFqsdT/ZourxX+GGuutnF6l",
+	"sk34v6jU8wnggSXh0H96CvTTDKvvAH40GFT7jtYgHwAYkg85KnKqHlUHHZNBourGnWIdrYt2lwwQ7jy6",
+	"YRfzR3dvNCQyOGmP9CsDl18vExX8w/cpq7+kKEewNjAYVI290EhwGSHPzvOnxgAWRvC519qd4oXtkb4Q",
+	"evRcHRlzbVZOtOF51sefYLdmu9Qvgj7Na8AnOcvmZYoRf2lb8DIf0N40x+aP3kX2I1zruTUeBX86eN//",
+	"Eu2CWqlW00NMDXHh34fKjrb2sJAwob/wGPFitXghd3G+umN6C5S7cJ3wIT67JvyxmzD4+63TeNi95dWl",
+	"oNwBikvOVTbi9bc7P0sYjzO+yEfvdOc3GCfFhJ578COBwRNV1VI7aF0UOxz+HwAA//9YC+kPFjgAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/api/api.gen.go
+++ b/pkg/api/api.gen.go
@@ -21,58 +21,147 @@ import (
 
 // Component defines model for Component.
 type Component struct {
-	AffectedBy  *IdList `json:"affectedBy,omitempty"`
-	DisplayName *string `json:"displayName,omitempty"`
-	Id          *Id     `json:"id,omitempty"`
-	Labels      *Labels `json:"labels,omitempty"`
+	// AffectedBy A list of impacts for a component or incident.
+	// In case of an incident the IDs refer to a component and vice versa.
+	AffectedBy *ImpactList `json:"affectedBy,omitempty"`
+
+	// DisplayName Short and describing name.
+	DisplayName *DisplayName `json:"displayName,omitempty"`
+
+	// Id Identfication for objects. UUID prefered.
+	Id *Id `json:"id,omitempty"`
+
+	// Labels Labels are free text key value pairs for components.
+	Labels *Labels `json:"labels,omitempty"`
 }
 
-// Id defines model for Id.
+// Date Point in time. Nullable for open ends.
+type Date = time.Time
+
+// Description A longer text for detailed informations.
+type Description = string
+
+// DisplayName Short and describing name.
+type DisplayName = string
+
+// Id Identfication for objects. UUID prefered.
 type Id = string
 
-// IdList defines model for IdList.
-type IdList = []Id
+// Impact An impact connects a component and an incident with an impact type.
+type Impact struct {
+	// Reference Identfication for objects. UUID prefered.
+	Reference *Id         `json:"reference,omitempty"`
+	Type      *ImpactType `json:"type,omitempty"`
+}
+
+// ImpactList A list of impacts for a component or incident.
+// In case of an incident the IDs refer to a component and vice versa.
+type ImpactList = []Impact
+
+// ImpactType defines model for ImpactType.
+type ImpactType struct {
+	// Description A longer text for detailed informations.
+	Description *Description `json:"description,omitempty"`
+
+	// DisplayName Short and describing name.
+	DisplayName *DisplayName `json:"displayName,omitempty"`
+
+	// Id Identfication for objects. UUID prefered.
+	Id *Id `json:"id,omitempty"`
+}
 
 // Incident defines model for Incident.
 type Incident struct {
-	Affects     *IdList             `json:"affects,omitempty"`
-	BeganAt     *time.Time          `json:"beganAt,omitempty"`
-	Description *string             `json:"description,omitempty"`
-	EndedAt     *time.Time          `json:"endedAt"`
-	Id          *Id                 `json:"id,omitempty"`
-	ImpactType  *IncidentImpactType `json:"impactType,omitempty"`
-	Phase       *IncidentPhase      `json:"phase,omitempty"`
-	Title       *string             `json:"title,omitempty"`
-	Updates     *IdList             `json:"updates,omitempty"`
+	// Affects A list of impacts for a component or incident.
+	// In case of an incident the IDs refer to a component and vice versa.
+	Affects *ImpactList `json:"affects,omitempty"`
+
+	// BeganAt Point in time. Nullable for open ends.
+	BeganAt *Date `json:"beganAt"`
+
+	// Description A longer text for detailed informations.
+	Description *Description `json:"description,omitempty"`
+
+	// DisplayName Short and describing name.
+	DisplayName *DisplayName `json:"displayName,omitempty"`
+
+	// EndedAt Point in time. Nullable for open ends.
+	EndedAt *Date `json:"endedAt"`
+
+	// Id Identfication for objects. UUID prefered.
+	Id *Id `json:"id,omitempty"`
+
+	// Phase To reference a phase, its generation and order is needed.
+	Phase *PhaseReference `json:"phase,omitempty"`
+
+	// Updates Positive and incrementing number for ordering and identfication of e.g. sub resources.
+	Updates *Incremental `json:"updates,omitempty"`
 }
 
-// IncidentImpactType defines model for IncidentImpactType.
-type IncidentImpactType = string
-
-// IncidentPhase defines model for IncidentPhase.
-type IncidentPhase = string
-
-// IncidentUpdate defines model for IncidentUpdate.
+// IncidentUpdate An update is a sub resource to an incident.
+// It's identified by the incident ID and its own order.
+// Updates happen in a given order.
 type IncidentUpdate struct {
-	CreatedAt time.Time `json:"createdAt"`
-	Id        *Id       `json:"id,omitempty"`
-	Text      string    `json:"text"`
+	// CreatedAt Point in time. Nullable for open ends.
+	CreatedAt *Date `json:"createdAt"`
+
+	// Description A longer text for detailed informations.
+	Description *Description `json:"description,omitempty"`
+
+	// DisplayName Short and describing name.
+	DisplayName *DisplayName `json:"displayName,omitempty"`
+
+	// Order Positive and incrementing number for ordering and identfication of e.g. sub resources.
+	Order *Incremental `json:"order,omitempty"`
 }
 
-// Labels defines model for Labels.
+// Incremental Positive and incrementing number for ordering and identfication of e.g. sub resources.
+type Incremental = int
+
+// Labels Labels are free text key value pairs for components.
 type Labels map[string]string
 
-// ComponentIdPathParameter defines model for ComponentIdPathParameter.
+// Phase A single phase is just its name.
+// It can be referenced by its generation and order.
+// See: #/components/schemas/DisplayName
+type Phase = string
+
+// PhaseList Phase resources are always handled as a list.
+type PhaseList struct {
+	// Generation Positive and incrementing number for ordering and identfication of e.g. sub resources.
+	Generation *Incremental `json:"generation,omitempty"`
+	Phases     []Phase      `json:"phases"`
+}
+
+// PhaseReference To reference a phase, its generation and order is needed.
+type PhaseReference struct {
+	// DisplayName Short and describing name.
+	DisplayName *DisplayName `json:"displayName,omitempty"`
+
+	// Generation Positive and incrementing number for ordering and identfication of e.g. sub resources.
+	Generation *Incremental `json:"generation,omitempty"`
+
+	// Order Positive and incrementing number for ordering and identfication of e.g. sub resources.
+	Order *Incremental `json:"order,omitempty"`
+}
+
+// ComponentIdPathParameter Identfication for objects. UUID prefered.
 type ComponentIdPathParameter = Id
 
-// IncidentIdPathParameter defines model for IncidentIdPathParameter.
+// ImpactTypeIdPathParameter Identfication for objects. UUID prefered.
+type ImpactTypeIdPathParameter = Id
+
+// IncidentIdPathParameter Identfication for objects. UUID prefered.
 type IncidentIdPathParameter = Id
 
-// IncidentUpdateIdPathParameter defines model for IncidentUpdateIdPathParameter.
-type IncidentUpdateIdPathParameter = Id
+// IncidentUpdateIdPathParameter Positive and incrementing number for ordering and identfication of e.g. sub resources.
+type IncidentUpdateIdPathParameter = Incremental
 
-// IdResponse defines model for IdResponse.
+// IdResponse Identfication for objects. UUID prefered.
 type IdResponse = Id
+
+// IncrementalResponse Positive and incrementing number for ordering and identfication of e.g. sub resources.
+type IncrementalResponse = Incremental
 
 // SuccessResponse defines model for SuccessResponse.
 type SuccessResponse = bool
@@ -80,23 +169,30 @@ type SuccessResponse = bool
 // ComponentRequest defines model for ComponentRequest.
 type ComponentRequest = Component
 
+// ImpactTypeRequest defines model for ImpactTypeRequest.
+type ImpactTypeRequest = ImpactType
+
 // IncidentRequest defines model for IncidentRequest.
 type IncidentRequest = Incident
 
-// IncidentUpdateRequest defines model for IncidentUpdateRequest.
+// IncidentUpdateRequest An update is a sub resource to an incident.
+// It's identified by the incident ID and its own order.
+// Updates happen in a given order.
 type IncidentUpdateRequest = IncidentUpdate
 
 // GetIncidentsParams defines parameters for GetIncidents.
 type GetIncidentsParams struct {
-	// Start Start of time frame to query for (RFC3339)
+	// Start Start of time frame to query for (RFC3339).
 	Start time.Time `form:"start" json:"start"`
 
-	// End End of time frame to query for (RFC3339)
+	// End End of time frame to query for (RFC3339).
 	End time.Time `form:"end" json:"end"`
 }
 
-// PutPhasesJSONBody defines parameters for PutPhases.
-type PutPhasesJSONBody = []IncidentPhase
+// GetPhaseListParams defines parameters for GetPhaseList.
+type GetPhaseListParams struct {
+	Generation *Incremental `form:"generation,omitempty" json:"generation,omitempty"`
+}
 
 // CreateComponentJSONRequestBody defines body for CreateComponent for application/json ContentType.
 type CreateComponentJSONRequestBody = Component
@@ -105,7 +201,10 @@ type CreateComponentJSONRequestBody = Component
 type UpdateComponentJSONRequestBody = Component
 
 // CreateImpactTypeJSONRequestBody defines body for CreateImpactType for application/json ContentType.
-type CreateImpactTypeJSONRequestBody = IncidentImpactType
+type CreateImpactTypeJSONRequestBody = ImpactType
+
+// UpdateImpactTypeJSONRequestBody defines body for UpdateImpactType for application/json ContentType.
+type UpdateImpactTypeJSONRequestBody = ImpactType
 
 // CreateIncidentJSONRequestBody defines body for CreateIncident for application/json ContentType.
 type CreateIncidentJSONRequestBody = Incident
@@ -119,71 +218,77 @@ type CreateIncidentUpdateJSONRequestBody = IncidentUpdate
 // UpdateIncidentUpdateJSONRequestBody defines body for UpdateIncidentUpdate for application/json ContentType.
 type UpdateIncidentUpdateJSONRequestBody = IncidentUpdate
 
-// PutPhasesJSONRequestBody defines body for PutPhases for application/json ContentType.
-type PutPhasesJSONRequestBody = PutPhasesJSONBody
+// CreatePhaseListJSONRequestBody defines body for CreatePhaseList for application/json ContentType.
+type CreatePhaseListJSONRequestBody = PhaseList
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
-
+	// Get a list of components.
 	// (GET /components)
 	GetComponents(ctx echo.Context) error
-	// Create a new component
+	// Create a new component.
 	// (POST /components)
 	CreateComponent(ctx echo.Context) error
-	// Delete a component
+	// Delete a component.
 	// (DELETE /components/{componentId})
 	DeleteComponent(ctx echo.Context, componentId ComponentIdPathParameter) error
-	// Get specific component by id
+	// Get a specific component by id.
 	// (GET /components/{componentId})
 	GetComponent(ctx echo.Context, componentId ComponentIdPathParameter) error
-	// Fully or partially change a component
+	// Update a component.
 	// (PATCH /components/{componentId})
 	UpdateComponent(ctx echo.Context, componentId ComponentIdPathParameter) error
-
+	// Get a list of impact types.
 	// (GET /impacttypes)
-	GetImpacttypes(ctx echo.Context) error
-	// Create a new impact type
+	GetImpactTypes(ctx echo.Context) error
+	// Create a new impact type.
 	// (POST /impacttypes)
 	CreateImpactType(ctx echo.Context) error
-	// Delete an impact type
-	// (DELETE /impacttypes/{impactType})
-	DeleteImpactType(ctx echo.Context, impactType IncidentImpactType) error
-	// Get list of incidents
+	// Delete an impact type.
+	// (DELETE /impacttypes/{impactTypeId})
+	DeleteImpactType(ctx echo.Context, impactTypeId ImpactTypeIdPathParameter) error
+	// Get a specific impact type by id.
+	// (GET /impacttypes/{impactTypeId})
+	GetImpactType(ctx echo.Context, impactTypeId ImpactTypeIdPathParameter) error
+	// Update a specific impact type.
+	// (PATCH /impacttypes/{impactTypeId})
+	UpdateImpactType(ctx echo.Context, impactTypeId ImpactTypeIdPathParameter) error
+	// Get a list of incidents between two points in time.
 	// (GET /incidents)
 	GetIncidents(ctx echo.Context, params GetIncidentsParams) error
-	// Create a new incident
+	// Create a new incident.
 	// (POST /incidents)
 	CreateIncident(ctx echo.Context) error
-	// Delete a incident
+	// Delete an incident.
 	// (DELETE /incidents/{incidentId})
 	DeleteIncident(ctx echo.Context, incidentId IncidentIdPathParameter) error
-	// Get specific incident by id
+	// Get a specific incident by id.
 	// (GET /incidents/{incidentId})
 	GetIncident(ctx echo.Context, incidentId IncidentIdPathParameter) error
-	// Fully or partially change a incident
+	// Update an incident.
 	// (PATCH /incidents/{incidentId})
 	UpdateIncident(ctx echo.Context, incidentId IncidentIdPathParameter) error
-	// Get updates of a specific incident
+	// Get a list of updates from a specific incident.
 	// (GET /incidents/{incidentId}/updates)
 	GetIncidentUpdates(ctx echo.Context, incidentId IncidentIdPathParameter) error
-	// Create a new update to a specific incident
+	// Create a new update to a specific incident.
 	// (POST /incidents/{incidentId}/updates)
 	CreateIncidentUpdate(ctx echo.Context, incidentId IncidentIdPathParameter) error
 	// Delete a specific update from a specific incident
 	// (DELETE /incidents/{incidentId}/updates/{updateId})
 	DeleteIncidentUpdate(ctx echo.Context, incidentId IncidentIdPathParameter, updateId IncidentUpdateIdPathParameter) error
-	// Get a specific update from a specific incident
+	// Get a specific update from a specific incident.
 	// (GET /incidents/{incidentId}/updates/{updateId})
 	GetIncidentUpdate(ctx echo.Context, incidentId IncidentIdPathParameter, updateId IncidentUpdateIdPathParameter) error
-	// Update a specific update from a specific incident
+	// Update a specific update from a specific incident.
 	// (PATCH /incidents/{incidentId}/updates/{updateId})
 	UpdateIncidentUpdate(ctx echo.Context, incidentId IncidentIdPathParameter, updateId IncidentUpdateIdPathParameter) error
-
+	// Get the current generation list of phases.
 	// (GET /phases)
-	GetPhases(ctx echo.Context) error
-	// Create a new list of phases.
-	// (PUT /phases)
-	PutPhases(ctx echo.Context) error
+	GetPhaseList(ctx echo.Context, params GetPhaseListParams) error
+	// Create a new generation of the phase list.
+	// (POST /phases)
+	CreatePhaseList(ctx echo.Context) error
 }
 
 // ServerInterfaceWrapper converts echo contexts to parameters.
@@ -257,12 +362,12 @@ func (w *ServerInterfaceWrapper) UpdateComponent(ctx echo.Context) error {
 	return err
 }
 
-// GetImpacttypes converts echo context to params.
-func (w *ServerInterfaceWrapper) GetImpacttypes(ctx echo.Context) error {
+// GetImpactTypes converts echo context to params.
+func (w *ServerInterfaceWrapper) GetImpactTypes(ctx echo.Context) error {
 	var err error
 
 	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.GetImpacttypes(ctx)
+	err = w.Handler.GetImpactTypes(ctx)
 	return err
 }
 
@@ -278,16 +383,48 @@ func (w *ServerInterfaceWrapper) CreateImpactType(ctx echo.Context) error {
 // DeleteImpactType converts echo context to params.
 func (w *ServerInterfaceWrapper) DeleteImpactType(ctx echo.Context) error {
 	var err error
-	// ------------- Path parameter "impactType" -------------
-	var impactType IncidentImpactType
+	// ------------- Path parameter "impactTypeId" -------------
+	var impactTypeId ImpactTypeIdPathParameter
 
-	err = runtime.BindStyledParameterWithLocation("simple", false, "impactType", runtime.ParamLocationPath, ctx.Param("impactType"), &impactType)
+	err = runtime.BindStyledParameterWithLocation("simple", false, "impactTypeId", runtime.ParamLocationPath, ctx.Param("impactTypeId"), &impactTypeId)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter impactType: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter impactTypeId: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.DeleteImpactType(ctx, impactType)
+	err = w.Handler.DeleteImpactType(ctx, impactTypeId)
+	return err
+}
+
+// GetImpactType converts echo context to params.
+func (w *ServerInterfaceWrapper) GetImpactType(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "impactTypeId" -------------
+	var impactTypeId ImpactTypeIdPathParameter
+
+	err = runtime.BindStyledParameterWithLocation("simple", false, "impactTypeId", runtime.ParamLocationPath, ctx.Param("impactTypeId"), &impactTypeId)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter impactTypeId: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.GetImpactType(ctx, impactTypeId)
+	return err
+}
+
+// UpdateImpactType converts echo context to params.
+func (w *ServerInterfaceWrapper) UpdateImpactType(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "impactTypeId" -------------
+	var impactTypeId ImpactTypeIdPathParameter
+
+	err = runtime.BindStyledParameterWithLocation("simple", false, "impactTypeId", runtime.ParamLocationPath, ctx.Param("impactTypeId"), &impactTypeId)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter impactTypeId: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.UpdateImpactType(ctx, impactTypeId)
 	return err
 }
 
@@ -477,21 +614,30 @@ func (w *ServerInterfaceWrapper) UpdateIncidentUpdate(ctx echo.Context) error {
 	return err
 }
 
-// GetPhases converts echo context to params.
-func (w *ServerInterfaceWrapper) GetPhases(ctx echo.Context) error {
+// GetPhaseList converts echo context to params.
+func (w *ServerInterfaceWrapper) GetPhaseList(ctx echo.Context) error {
 	var err error
 
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetPhaseListParams
+	// ------------- Optional query parameter "generation" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "generation", ctx.QueryParams(), &params.Generation)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter generation: %s", err))
+	}
+
 	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.GetPhases(ctx)
+	err = w.Handler.GetPhaseList(ctx, params)
 	return err
 }
 
-// PutPhases converts echo context to params.
-func (w *ServerInterfaceWrapper) PutPhases(ctx echo.Context) error {
+// CreatePhaseList converts echo context to params.
+func (w *ServerInterfaceWrapper) CreatePhaseList(ctx echo.Context) error {
 	var err error
 
 	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.PutPhases(ctx)
+	err = w.Handler.CreatePhaseList(ctx)
 	return err
 }
 
@@ -528,9 +674,11 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.DELETE(baseURL+"/components/:componentId", wrapper.DeleteComponent)
 	router.GET(baseURL+"/components/:componentId", wrapper.GetComponent)
 	router.PATCH(baseURL+"/components/:componentId", wrapper.UpdateComponent)
-	router.GET(baseURL+"/impacttypes", wrapper.GetImpacttypes)
+	router.GET(baseURL+"/impacttypes", wrapper.GetImpactTypes)
 	router.POST(baseURL+"/impacttypes", wrapper.CreateImpactType)
-	router.DELETE(baseURL+"/impacttypes/:impactType", wrapper.DeleteImpactType)
+	router.DELETE(baseURL+"/impacttypes/:impactTypeId", wrapper.DeleteImpactType)
+	router.GET(baseURL+"/impacttypes/:impactTypeId", wrapper.GetImpactType)
+	router.PATCH(baseURL+"/impacttypes/:impactTypeId", wrapper.UpdateImpactType)
 	router.GET(baseURL+"/incidents", wrapper.GetIncidents)
 	router.POST(baseURL+"/incidents", wrapper.CreateIncident)
 	router.DELETE(baseURL+"/incidents/:incidentId", wrapper.DeleteIncident)
@@ -541,35 +689,46 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.DELETE(baseURL+"/incidents/:incidentId/updates/:updateId", wrapper.DeleteIncidentUpdate)
 	router.GET(baseURL+"/incidents/:incidentId/updates/:updateId", wrapper.GetIncidentUpdate)
 	router.PATCH(baseURL+"/incidents/:incidentId/updates/:updateId", wrapper.UpdateIncidentUpdate)
-	router.GET(baseURL+"/phases", wrapper.GetPhases)
-	router.PUT(baseURL+"/phases", wrapper.PutPhases)
+	router.GET(baseURL+"/phases", wrapper.GetPhaseList)
+	router.POST(baseURL+"/phases", wrapper.CreatePhaseList)
 
 }
 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/8xZTW/jNhD9KwTbQwtoIzvppb5lvd2F0aBrJLuXLnKgxVHMhURqSaqtYei/FyQl69M2",
-	"/aEgQA6xNOI8vpl5M6K2OBJpJjhwrfBsizMiSQoapP01r+4t6JLo9bK6ae4xjmc4I3qNA8xJCnhWL7Wg",
-	"OMASfuRMAsUzLXMIsIrWkBLz6M8SYjzDP4W179DdVeGC4qII8IJHjHo7Zjvra/n9mlGiwc97Xtpe5rtw",
-	"T4PS7wVl0Ob/0d0x1yLBNXD7L8myhEVEM8HD70pwc83P425h55iCiiTLzEJ4hp+AU0RQVNvUvFwbSLXu",
-	"fhwcsZ1NNz5joXGr+2BCeWVqwqcywZUL3YI+lj+vh44OIbpHZdogCTqXXBl4iw+GrKc8ikCps4DoTWZy",
-	"eyVEAoQfdrwmCinnK86TZINkzi0jJfJWKluVkSIDqcssJ3EMkQb6fnOcgQembB5QprKEbP6yFbhDq7Rk",
-	"/MXcZ9SHzQAnZAWJOmb74KyqGnUV/s04eQ4q32L1HSKXo9a3BEI/82RTSUEPYrkZoykaUuWHt1yFSEk2",
-	"zXrYx6ryp3QFL4Tf25ViIVOi8Qyb3H6nWQp4YAOtdBiIAXAK9MCCPE8SskpgL0O+QWRpRiL9xT7uV+CL",
-	"+okiwNmaKO9Hl9bYhILpZDj5nCZ4U++ZVX3oQ77bMA9ZlCLXS5xIAtEHA3d2oDT8pwcw9QkoTYMGmCFO",
-	"HnbVSyhlJhFJsmxtpge1s4bxzXgsrK0LKH6aP6EnTXSu0JK8ALpfLnCA/wGpnPBNbyZmJZEBJxnDM3x3",
-	"M7m5xYEdC6zXsD1UvYDdtcFl5dYIBP4Eel5bdbrH7WRyklp7Kci82dDbQtJX989/uquZUAPg5zYs9YLN",
-	"2WWvirfGm7A32xQ9Dqb7VyrtwkabtQ0nT1MiNzuEiCAO/zZHmSJoRifcNmbWwrijkICrivaOP9jrzR03",
-	"R+Vvwzhrk3DvKF08D8f+8L67rb29eQe2O8MdTcPxNzX+8GrztsnFJ9BIZRCxmEU1H2i1QcxqUkZ0tO7z",
-	"4tRxNGquXywXJ81HO7oJiTIiNSPmR7Qm/KWTR6aAXMM1EnJQ3xYNs9cQuOHufg2la6zYi95V3zya0Iti",
-	"REl0IUTaeWrHNNzWE5WHKLbI6VTJ0Mt6l8szXpiH2BpRR/kAXSWEwwWwM+oR03mt1ERqJGJkJiwUG0uk",
-	"BfqRg9ygWEj0y+PH+d3d3e+/4sBxam/VpCqzwEE+KcQkT8wodzu5vX03mb6bTL9MJzP7dzOZTv7Ggde4",
-	"VwRd9H9wegl24NQf+W+XIH9+TRXy1p5ut0qYsrlQp9gxdao8ntFZugc7Y0pOfdbTLKBwWx/f+ahNvdnT",
-	"OvK+I8VRB7Dm2dUxlRh9R6Of2B0evnZnZn6z10i0XL0+Rh28fGombJw3HMuxr6Xpm0m1kyS1Opc9U1hL",
-	"noy2kn5a+qpsCeJNZGX7GHxE7XbUmb4+yNzx5Ay31WeSEzT+2lQH3o8Of/8ZtVXsaC25jqVI9+WpX5m/",
-	"feJe6avNoBqcxrhXq3qbtI+kLRdnvnNwUhyMztjT+oPNbuksXrMz1V8FfE8b8gHsy7yJ/bxThuvAHiHc",
-	"rX5SveO4YN5Yl/8HAAD//7iWRZCMIAAA",
+	"H4sIAAAAAAAC/9Ra32/bvBX9VwhuwL4PUG0n2cv81i/ZBmNFayTty9o80OKVzU6mVJJKZhj+34dLShZl",
+	"SZb8Q2kH9KGxKPLcy3PP4Q9taZis00SCNJpOtzRliq3BgLJ/3RfPZnzOzGpePMRnHHSoRGpEIum0bElm",
+	"D0RoouBHJhRwIiRJmVmNaEAFNsQ/aEAlWwOdloPPOA1o8RKdGpVBQHW4gjXDwf6sIKJT+qdxiXbsnurx",
+	"jNPdLqCzdcpC83mTQidY15SYTQqnwRXeGBfjlaHgfVJbNDwR6r77awH9knJmoD/czLYngpPfhFSwBmlY",
+	"/PsJIWT5gOcHIMNiXLrDULAb0OaPhAuoEvzRPcHfwkQakPa/LE1jETKMbPxdY3jbnkPvO3YDV1P0BJIT",
+	"RvavjWiFv9fGUvbcDkYSURaFw5PP49XR5P0exZK3qQBx/BsKjuu9D6ic2CPqGKXTRGrHphl/zP+8Hjze",
+	"BOk9yZlMFJhMSY34Zg9FugrSXx/NYUH1gVW+Y/E9ZWEIWp+FDclJp3SRJDEweRzCimmi3VhRFscbojLp",
+	"5iyPplL/1vtUkoIyuTSwKILQAP9j06++PghtMD4udBqzzUerYcdffPCa7gIqeB82BDRmC4h1V9sPrlUh",
+	"e049v+Igz0GRyGTxHUKL+gHJX9PyeSKkQZU2Yg0j8jGLY7aIgUSJIkkKkoDkGtU7StSaGTqlWBnvsDXK",
+	"eN68EO18UG2UkEs7qD/YtjaTcSKXoIiB/xo7IgfDRGxtw40nEmlHr3dcnYODel4lyhAmOXG/L4RcErSc",
+	"xq5mvMHiUAainKYuGTaRekS+fJk9kFRBBAr4yDoX459kvGlNgmNPQ/x7SQ4TKbF33zIsfl+UXoVZ1WQ8",
+	"OOC0wyVD6Ec0h/UEc2kgllccTVMstCFJlKPWNpd+lIkqveCbnEkSMg34gh+6WeEyDpcVEdIlqeXpRYRA",
+	"XkBpNvomca1hYK37BVamgTKl2Kbq1HXV4FVKH61+r+kb6EY/Hdi7c4se6tPEcAFLJt+bzoCs9QY/JXsg",
+	"OfD+EPuKdLpiuhPKHBs97otyF+RrXn2aEZ80s/lCp0lvihU7Ko3OFkSBTjIVgq0pWalE8xdN7B8iEsDJ",
+	"YmOrUHhbFSw8YTRJXiVJFAc1+ibd2JqsWIruISRhZCleoGxRk6xQATOnTNDP4JBFf8mcuQ4CL9qWKdz3",
+	"0ODVWhjxAi7xRUvrbdl6Acr5FI6Dv9lGFRtLIgKj5agy8drNSIuHCWlgCQqRfdgvSRjnAvtj8bwyjzXf",
+	"q6J3HRCmgEQKwJn+f2BDXlicAUmZUM4dysR6dl2maF6U3aHTaCGXMRBblsjw75k2lp/W+ZHRJGSSLIDs",
+	"TdLSGpssQYJyWcK8FVx9ApiSLnrYBNaCtzCbTdE+KmfApoTFr2yDZSM5rn8YFihaZ93hS6gn0THXK9tF",
+	"L3d0ea6Z4wGtPTT7EZ7bZu3RX5xUc/I5KWeFMDeJQevU4PRKAO4WYAf+fHaNn53Zq4mDh6CeRHwJ18W2",
+	"1oTBVTd9un8iT4aZTJM5WwJ5P5/RgOJCyKX1ZjSxAFOQLBV0Su9Gk9Et5oyZlU3XuHo6uARLWEyoxYGL",
+	"Y/pPMPdlq4Mt8e1kctIOrxf5vMOVGgFryvLpX27Tl63XTG0c3rx8UPN8PcEySHRDiPdWlsth/ZOk1u1h",
+	"5bBpXDtp2tUyddPeU95u7J0wVINyCAkjEl4rB0u7wJ/E8dY7cd25QovBLQeqIT/Y3/2Q/aPhr81Ayybj",
+	"1qPj3XMzRY4HfnhqUI3ega0dqXXS9WdH1TqdjqM6hVBEIvS2M+hI3DGVmXBVD88tsQaL8Pqsv3jyXcQH",
+	"k4+0d5tK1Iej4lVu595Gvfwd88Xy5W33uwXMG/mMuawfUA8oYdXT6IPZHG/9i5geMlYJ/LR6aL9WGlLI",
+	"6sfx3ex9g9De4Dqihe97KfTy0lcMB0zRACV0PT1syllRTPlG/bgw7hvV0nZwomqYsmpkxBr3b2xtjwx+",
+	"ZKA2dtP22+M/7u/u7v72+/6mzz4rr/o09nD0no9DxLLY0Cm9ndzevpvcvJvcfL6ZTO2/0eRm8u+2Y+iD",
+	"zdcuOIT/d9w4XAAeJO8P/a+XQH9+E3/aX9Bd7k4Fg8gCzCuAJOY1IWki8KfiWqHTtQo85xTcwSXmkI5V",
+	"3llWKmy8La/i+1hVGe2JUtXyPcHANuXf1HYJyeAxDX5B3elOxQFoX2saJjNXr5KrmZLsVydj7xy8i1X5",
+	"ofKvQ66TVLb47uBirc0zRiKVrJso2Vtnc0S/BCOr33wMqN751Ye9PGxKXTdVx9vie6UTVP7auQ56v9r8",
+	"NdeghzP7vObJbmNqHyv5f0ncG32j1OVLHRnvb1S/Zt4HUpcBtmLdE4FKU17GtNVBeYFUm4qmLUrlIuac",
+	"b72GpHcZS19mmxWQMFMKV1reDVBhhS59nYbn5/CAQ9eP6zzvaviW74iJeanA/eyquO50V4UI4n8BAAD/",
+	"/2mROTrvLQAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/api/api.gen.go
+++ b/pkg/api/api.gen.go
@@ -21,9 +21,9 @@ import (
 
 // Component defines model for Component.
 type Component struct {
-	// AffectedBy A list of impacts for a component or incident.
-	// In case of an incident the IDs refer to a component and vice versa.
-	AffectedBy *ImpactList `json:"affectedBy,omitempty"`
+	// ActivelyAffectedBy A list of impacts for an component.
+	// Impacts reference incidents.
+	ActivelyAffectedBy *ImpactIncidentList `json:"activelyAffectedBy,omitempty"`
 
 	// DisplayName Short and describing name.
 	DisplayName *DisplayName `json:"displayName,omitempty"`
@@ -57,9 +57,13 @@ type Impact struct {
 	Type      *ImpactType `json:"type,omitempty"`
 }
 
-// ImpactList A list of impacts for a component or incident.
-// In case of an incident the IDs refer to a component and vice versa.
-type ImpactList = []Impact
+// ImpactComponentList A list of impacts for an incident.
+// Impacts reference components.
+type ImpactComponentList = []Impact
+
+// ImpactIncidentList A list of impacts for an component.
+// Impacts reference incidents.
+type ImpactIncidentList = []Impact
 
 // ImpactType defines model for ImpactType.
 type ImpactType struct {
@@ -78,9 +82,9 @@ type ImpactTypeList = []ImpactType
 
 // Incident defines model for Incident.
 type Incident struct {
-	// Affects A list of impacts for a component or incident.
-	// In case of an incident the IDs refer to a component and vice versa.
-	Affects *ImpactList `json:"affects,omitempty"`
+	// Affects A list of impacts for an incident.
+	// Impacts reference components.
+	Affects *ImpactComponentList `json:"affects,omitempty"`
 
 	// BeganAt Point in time. Nullable for open end timeframes.
 	BeganAt *Date `json:"beganAt"`
@@ -95,7 +99,7 @@ type Incident struct {
 	EndedAt *Date `json:"endedAt"`
 
 	// Id Identification for objects. UUID preferred.
-	Id *Id `json:"id,omitempty"`
+	Id Id `json:"id"`
 
 	// Phase To reference a phase, its generation and order is needed.
 	Phase *PhaseReference `json:"phase,omitempty"`
@@ -121,7 +125,7 @@ type IncidentUpdate struct {
 	DisplayName *DisplayName `json:"displayName,omitempty"`
 
 	// Order Positive and incrementing number for ordering and identfication of e.g. sub resources.
-	Order *Incremental `json:"order,omitempty"`
+	Order Incremental `json:"order"`
 }
 
 // IncidentUpdateList defines model for IncidentUpdateList.
@@ -154,10 +158,10 @@ type PhaseReference struct {
 	DisplayName *DisplayName `json:"displayName,omitempty"`
 
 	// Generation Positive and incrementing number for ordering and identfication of e.g. sub resources.
-	Generation *Incremental `json:"generation,omitempty"`
+	Generation Incremental `json:"generation"`
 
 	// Order Positive and incrementing number for ordering and identfication of e.g. sub resources.
-	Order *Incremental `json:"order,omitempty"`
+	Order Incremental `json:"order"`
 }
 
 // ComponentIdPathParameter Identification for objects. UUID preferred.
@@ -777,42 +781,41 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/9RbW4/buBX+KwRboLuAInsmCxQ1UBTZme3CQJC4meSlmzzQ0pHNVKYUkpqpYfi/FyR1",
-	"oa6m5EtSYB5mJIrn9p0bD+eAg2SXJgyYFHhxwCnhZAcSuP7roXi3DFdEblfFS/UuBBFwmkqaMLyoVqLl",
-	"I6ICcfiWUQ4hogylRG597GGqFqo/sIcZ2QFeVMSXIfZw8RFeSJ6Bh0WwhR1RxP7MIcIL/KdZxe3MvBWz",
-	"ZYiPRw//Dgw4Uez8KwO+H+D1vf6FxGhTfqLY/KY+89Fv/sZH/6he/f2vBet6QcV7tQQ7s8oCDjtgksSa",
-	"5+UuJYH8uE/hpILNUiT3KYxTMbVonKvjJQto6AKHYuFIVsvtL8XopzQkEt7zELgrx5n+BCXqG/QTZYXB",
-	"fh4hSFaRnS5JDStHsw0I+WsSUqh75wfzRj0LEiaB6V9JmsY00ACdfRVKyIMj6XJjQ7iuqCdgISKo/MzH",
-	"NSBfmpdq535mGKKVdxh+cmtenJt830Fe8jU1RgwQr8WO2d2FqRzemrfVlgh4S8XFtVRuPIAfBi8opkKi",
-	"JEKpWi98bFAu0oSJBsINl+bNKDZTnqTAZe4xIZHu4M8F8LBCFV7gZP0Vgk6R3qDcNxEHmXEmECllqyho",
-	"nVs+e1tppktS9/QqzV5AAiuFjsyckySpyBnfDC8gAg0dU9IUjhlaPjbi6w09oU70fFewgrRoZY0bS3SG",
-	"SfpyzS0tY5G8gF3y3UQjdd5UlHMM0p9wv4NNKsKXs0yetUVnSfEdpLuAsexCRBfKFxBE1+y3yCTMtAfN",
-	"KuomlrCLq4nw0vWWBpmpufKtaxVXmzkSRRBICH/du4VZw6OHQyrSmOzf6dZo+MNHa+nRc8ytHo7JGmJx",
-	"au1bs6popUxH9oci8qWlR69eeupEL2EnRpRbigoJ37N4X/R9OQ3COdmr94/Kk1qN6CqhTKr+UtId+Ohd",
-	"FsdkHQOKEo6SFBhS9bN6F6leVqgONEr4jki8UPiBV+qdakXzDxvUheSUbTR5m+yhBZs4YRvgSMJ/JXqh",
-	"cotCkITGuvc1BHUd1bVx3eCN8n+bcIkIC5F5vqZsg1Tb3LnVMuzo1FX4oFHuU0Yv2mzCR58+LR9RyiEC",
-	"ziH0ca8RLBIarB0aKDN9kDCmtrdrYS2BHc60iprVgddwIc0YsADccG14PaekKcQrQNwycq00E1qZtpQJ",
-	"r7LrZ7ZkKFCRI4lqosstoOWjQFo6JJOWnp5pAOgZuCD+Z4Y9N1fK7XJs+40lcjuC1kE9GGyspTcIU25h",
-	"p1Fzu8YdGwWnA09Zc/XEeDEuwK9hQ9gbeVJrunDwvouJgIUQurPomnh0InVK2B9Kzz96+fGgGFGplPne",
-	"BUJ2c+AMoLIMd4dPXgt2Rc78EJWqmCmyNeIgkowHoKMDq8UU+ReBaB7SIUTrvY4n1DpAViGESoGSl6Lu",
-	"+swMbYG2JFU5kTLV3tNnqFa0gm/AgcgxKPgeQJ1UwtqgSPJD50raIYxYzcpYpBSdgBNeSnY7yh1BJX0G",
-	"Y+VipS4Kst0auMnvSij1TC9S1Mv0n0QI/I1fQ5kw5u/hizIJG+ANzroz5Ns8P1oLTZIsMrliSmTrirJz",
-	"erNteFqHb8sSl4QhNfOrVQ3ercKmIYneABEOKOIApq77D+zRM4kzQCmh3EhmH1h2IGdVhLxmKSEo28SQ",
-	"9xZUoK+ZkNptdXGnHB0FhKE1lLoz3q6WWIM4ZeHChZ8AFsghpmprt+SvGqU26DSTpdG0Vkj8QvYqoLBQ",
-	"Fbmk6MPbVdzEU8s8XQhnTzOqbhVADYevjSFzCl/6DPfBLkDrOvmYVIYpekSv1zrKwgwgNEV2owabHP0m",
-	"a/ZiYdPi4Etnd62aH+1uVKreCj89PKEnSWQm0IpsAL1ZLbGHVbFr1HrnzzWDKTCSUrzAr/25f690RuRW",
-	"q2tWn8BvQANWKVTzoVog/DvIh2pVY0pyP5/3iV6um3WPUnT3n+12hO8Nlf7JRZqIDsYedJqp2l57TLnv",
-	"58qaZM5aY8xjS7670/JZh/l1oQyH+cTJnmUcPVv1s4N1F+Fo3CMGU97URX7Uz22R7UsTf3QzWi2Z9V6q",
-	"OH5pCf5LRwOdBQEIEWWxj94l6CE/aaoLbXhsDW9OYuuqwoxB6SBCRQoBjWhgtZkqkYQGp0QG27aUply5",
-	"mqCXx/xU0xtBG6ZXWDc9vp6+DMWZqpWcFmh6RlVDkaY1GBqKNVarO0Hx7YsKV4w29UlRwwazg30zxyHi",
-	"1AQfB97+e0ZXiDntCdlpqF1XolGodYs8loiuseeK0l7BCc4OP12qKrygGDgOxqFyUUtbDbYk4TqMSLpT",
-	"zQ3Z6WMGfVtPdzQ/ffjnw+vXr//2s99zk0+oHQYvaoUQkSyWeIHv5/f3r+Z3r+Z3H+/mC/3jz+/m/+47",
-	"hm+0JUevyf5vqqQ+g3lgoTvrv5zD+jTH6pqODyaDwu5oDfIFgCH5kqA0oepRMRY5mSSK46wp3tG4O3bN",
-	"BFFNrmt+MTtUVyFdMkMl7ci40nOf8zpZwR7Tn/L6a4oyArWOyaA4rHTNBNcR8uI4PzcHMDeAz6zz8FO4",
-	"yM99fxB4dFwyGQptuZwo4smuCz/OYS0/e/0h4FO/2TopWNbvfwzEy3ysoEeMXdo7jbHZwbqbPSK0Xlrj",
-	"nvOnvVfYr3FcUCo113QfUl1C+P+HykZ7u1tKOKE/9xzxw2rxSuHicn3HaROocFGdyffhuZojjDVC778k",
-	"TcNh+6ZZG4JyCyjIOFfViHVu37ppP5xnbJFHW7r1bwWTckLHPfOBxGCJqnqpLTTuuB2P/wsAAP//JnBH",
-	"Zuk2AAA=",
+	"H4sIAAAAAAAC/9RbW2/cuBX+KwRboLuAohk7CxQdoCiy9nYxQJC4cfLSTR440pkZphpKIam4A2P+e8GL",
+	"JOo6lObiFPCDLVHkuXznnO+Q9DOO0l2WMmBS4MUzzggnO5DA9V93xbtl/EDk9qF4qd7FICJOM0lThhfV",
+	"SLS8R1QgDt9yyiFGlKGMyG2IA0zVQPUHDjAjO8CLavFljANcfIQXkucQYBFtYUfUYn/msMYL/KdZJe3M",
+	"vBWzZYwPhwD/Dgw4UeL8Kwe+H5D1vf6FJGhTfqLE/KY+C9Fv4SZE/6he/f2vheh6QCV7NQR7i8oiDjtg",
+	"kiRa5uUuI5H8uM/gqIHNUCT3GYwzMXXWONXGSxbR2AcOxcCRopbTn0vQT1lMJLznMXBfiXP9CUrVN+gn",
+	"ygqH/TxCkbxadromNawczDQg5K9pTKEenR/MG/UsSpkEpn8lWZbQSAN09lUoJZ89ly4nNgvXDfUILEYE",
+	"lZ+FuAbkc8tSzdwvDEO0ig4jj/Xm2aWx8w7KYsfUBDFAvJQ4ZnYfoSy8tWwPWyLgLRVnt1I58QB+GDyh",
+	"hAqJ0jXK1HgRYoNykaVMNBBupDRvRomZ8TQDLm3ExET6g98qEGCFKrzA6eorRJ0qvUE2NhEHmXMmECl1",
+	"q1bQNndi9rraTNekHulVmT2DBk4JHVk5J2lSLWdiMz6DCjT2LElTJGZoed/Ir1eMhPqip4eCk6RFq2pc",
+	"WaMTXNJXa67pGWfJM/jFziYapfOqqpzikP6C+wI+qRY+n2ds1RadlOIFtDuDs1wioonyGRTRnP0alYSZ",
+	"9qDJoq7iCZdcTYSX5lsaZIZz2alrjKstHIkk/Q7J/s16DZGE+Ne9X7qtJ6sAx1RkCdm/063S8AT3ztBD",
+	"4FlrA5yQFSTi2Ni3ZlSHFYM68dRlXsJOjCBbisiS+D1L9kXXZ9cgnJO9en+v4qjVhj6klEnVXUq6gxC9",
+	"y5OErBJA65SjNAOGFHtW79aqkxWq/1ynfEckXij0wCv1TjWi9sPG6kJyyjZ6eXfZ5xZokpRtgCMJ/5Xo",
+	"icotikESmujO1yyoWVTXxHX3Nsj/NuUSERYj83xF2QapprlzqmXc0acrKNG1jShjF+02EaJPn5b3KOOw",
+	"Bs4h7p5SQ7JD47KuRyljajqX+WqJ3eSlTdLkAkEjYLQgwCLwQ62R9RQCU6jXQm/LuzVGJrQV3UL6mS3t",
+	"m1IHt5H5zHDgFxHW3Ic2/Dtyg7+gVUvSJWnFZ6YIeixuHRe083c9qAZTmzP0CkmxHywlv/fNci4GPcxV",
+	"8Lt2PdF1xHO5Rlce4BVsCHsjjxpLs5XgRTwDLIbYX0Tf6qartxdL+FAmoENg9yTFCHpUkoxqA/MPJeWX",
+	"Liw1AtkPSSX398eRJaBdCdzu3FKVukW+QhxEmvMIkEyb2U3+RSBqKwnEaLVHclslDrS81xmfSoHSp4Ls",
+	"fWZmbYG2JFOlmDJE0IZ+h2pEqwZEHIgcg4KXAOok3uyCwkwwhAunKxqLjqLl8MJIKWIHsxJUEVjj2WKk",
+	"5h/5bgXcUAmliHqmB6nVS6aRrhGEm7CGLFthrByUSdgAb0jSXdre2sLmDDTVrShjSgiRr6qVvCuZ66fj",
+	"NntbcmUSx9QcjD3UINziUA1N9ASIcEBrDmAo439gj76TJAeUEcqNZu5OaAdSHoq01uQAgrJNArZpoQJ9",
+	"zYXUoal5owpmFBGGVlBRAB3Raohzwqc8WoTpI8ACeeRN17uV/lUH1gaZFrJ0mrYKSZ7IXiUNFiv+TIoG",
+	"v00YJ26H2pIgvCPLmLpFyhpBbSf90uerDy69rZvhY+rQMdtvBr0OUU5lALGh7A1GNTmpTTbmmbJhTYIv",
+	"nZ26aqV0hFGpOjX8ePeIHiWRuUAPZAPozcMSB/g7cGHMehPOtYAZMJJRvMCvw3l4q2xG5Faba1Y/zd+A",
+	"xqgyqJZDNVT4d6jYlMCNE5fb+bxP9XLcrPtYRu8k5Lsd4XuzSv8pSJaKDsHudK2smmj3yHPfL5VzKjpr",
+	"HYkeWvrdHNfPORioK2UktKdX7rnIIXBNP3t27jUcTHgkYFhLXeV7/dxV2b2A8Ue3oNWQWe8FjcOXluK/",
+	"dLTjeRSBEOs8CdG7FN3ZXau60kbG1kHQUWxdVJkxKB1EqMggomsaOc2+qh2xwSmR0batpWEkF1P0/Jif",
+	"6nqjaMP1CuumH9cnOUN5pmoVpyWanmOvoUzTOmQayjVOKzvB8O1LDxfMNvVTp4YPZs/uLR+PjFNTfBx4",
+	"++8sXSDntE/bjkPtshqNQq1f5nFU9M09F9T2AkFwcvrpMlURBcVm32AeKge1rNUQSxKu04ikO9XPkJ3e",
+	"PdA3/3QT89OHf969fv36bz+HPbcChZph8NJXDGuSJxIv8O389vbV/ObV/ObjzXyhf8L5zfzffZv6jU7k",
+	"EDTF/01R6hOEBxb7i/7LKaJPC6yuk/bBYlD4Ha1APgEwJJ9SlKVUPSoOWY4WiWKXakp0NO6hXbJAVKfg",
+	"tbiYPVfXKn0qQ6XtyLzSczf0MlXBPfI/FvWXVGUEaj2LQbEH6VsJLqPk2XF+ag1gfgCfOdvcx3Bht3N/",
+	"EHh0XFgZSm1WT7Tm6a4LP95pzW6v/hDwqd+SnZQs63dJBvKlPS2QaY/1jmNs9uzc8x6RWs9t8cD7097r",
+	"8JfYLiiNai3dh1SfFP7/YbLR0e5XEo7Yz79G/LBWvFC6OF/fcdwFKl1U2/B9eK6ODsY6offfm6bhsH1r",
+	"rQ1BuQUU5ZwrNuLs27du7Q/XGVfl0Z5u/YvCpJrQcWd9oDA4qqpeaguN+3KHw/8CAAD//xi7R8c1NwAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/api/api.gen.go
+++ b/pkg/api/api.gen.go
@@ -94,8 +94,8 @@ type Incident struct {
 	// Phase To reference a phase, its generation and order is needed.
 	Phase *PhaseReference `json:"phase,omitempty"`
 
-	// Updates Positive and incrementing number for ordering and identfication of e.g. sub resources.
-	Updates *Incremental `json:"updates,omitempty"`
+	// Updates An incident will have multiple references to updates and they should not be changed.
+	Updates *[]Incremental `json:"updates,omitempty"`
 }
 
 // IncidentUpdate An update is a sub resource to an incident.
@@ -697,38 +697,39 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/9RaW4/buBX+KwRboLuAYnsmfanfsjNtYTTYNWaSl27yQIvHNlOZ0pLUTA3D/704pC7U",
-	"zZIvmqRAHjIWRX7n9n3koQ40jHdJLEEaTecHmjDFdmBA2b8e8mcLvmRmu8wf4jMOOlQiMSKWdF6OJItH",
-	"IjRR8EcqFHAiJEmY2U5oQAUOxD9oQCXbAZ2Xiy84DWj+Ep0blUJAdbiFHcPF/qxgTef0T9MS7dQ91dMF",
-	"p8djQBe7hIXm0z6BXrBuKDH7BM6DK7w1rsYrQ8GHuDYfeCbUYvpbAf2ccGZgONzUjieCk5+EVLADaVj0",
-	"8xkmpNmClxsgw3xdekRTcBrQ5peYC6gm+JN7gr+FsTQg7X9ZkkQiZGjZ9JtG8w4Dly4mdgtXXfQMkhNG",
-	"itcmtJK/t8ZSztwNRhJRFoXDk8Xx5miyeU9iycZUgLj8GwuOm30IqCyxJ9RllE5iqV02LfhT9uft4PE2",
-	"SB9IlslEgUmV1Ihv8Zi7K0/626OpF9QQWOU7Ft9zGoag9UXYMDnpnK7iOAImT0PYMk20W2udRtGeqFS6",
-	"mGXWVOrfap+KE1Amowa2XkNogP+yH1ZfH4U2aB8XOonY/lfLYadffPSGHgMq+JBsCGjEVhDpvrEf3aic",
-	"9hx7/o6LfA1yR8arbxBa1I+Y/A0uX8ZCGmRpI3YwIb+mUcRWEZB1rEicgCRYGvhsjXKgkcfXsdoxQ+cU",
-	"a+QdPkNCz17M6TtbXhsl5MYu7y97aMQ0iuUGFDHwX0NehdkSDoaJyCqIW1DEEldvTlyNRq2yt7EyhElO",
-	"3O8rITcExad1qgVvETskBLHOMtb5xfpUT8jnz4tHkihYg1LAJ1bFGP9NRvtON7hMavFAQc9hLCVO78uH",
-	"tcAnKOuiOqUHtfy2wECGMCzpHNYzhKYlybxCaQuy0IbE6wy1ts70rYxVqQtf5EKSkGnAF3zTzRa3dLjF",
-	"WGPCxA0/vYgQyAsozSZfJO47DOz0MMNKN1CmFNtXVbvJILya1CeZwBv6BhwyjBMKpe7gRn0eMa5gw+QH",
-	"02uQleHgu3gPJAc+HOJQwk62TPdCWeKgp6Ioj0G2/9XnifJZkc02PW18k+/ekWl0uiIKdJyqEGxNyUol",
-	"mr9oIjIiBE5We1uFwju2YOEJo0n8KkmsOKjJF+nW1mTLElQSIQkjG/EC5YgGZYUKmDknQN8jhyz6a2Lm",
-	"Jgg8aztCWMzQottaGPECzvH5SKtu6W4FygkVroO/2UEYqkLH4jWByWZSCbx2EenQMCENbEAhso/F9oRx",
-	"LnA+Fi0rcWzoXhW9m4AwBWStAJzs/wf25IVFKZCECeXUoXSsJ9ili5Z52dWVRgu5iYDYssQM/5ZqY/PT",
-	"aj9mNAmZJCsghUjatMYhG5CgnJfQb3muPgPMyYC6tj5s2G/HtOuifVQGwXqFRa9sj5UjOe6BGNYoqmdT",
-	"5Eu0Z2VkRll2ikEC6Vzd0MdaZntoihW+dgXuyd+fVH3yKS4DQ5iLY9AZHYywBOBuD1aT6IvL/GLP3owf",
-	"PARNJ+JLuDe25SYMbr3p88MzeTbMpJos2QbIh+WCBhT3Qs6td5OZBZiAZImgc/p+Mpvco8+Y2Vp3TavN",
-	"wg3YhEWHWhy4Q6b/BPNQjqqdkO9ns7MOfIOSz+u1NBKwQS6//cudAdPdjqm9w5uVD9KeTylYBrFuMfHB",
-	"MnO5rN9Y6jwtVnpP00bj6djw1F33TNm4qddwqBrlEBJGJLxW+kzHwA/i9OA1YI+u0CJwO4KqyY/2d99k",
-	"v1P8ezvQcsi0s5N8/NqeIqcNrzcRqtY7sI0OW2+6fm+rOsPpclQnEOJZ0zvRoChxl6nMhNumeW6XNZqF",
-	"t8/6q4PvLK4FH9PenSuRH06SV3miexv28g/NV9OXd+LvJzBv5Qti2exXj0hh1eZ0LZrTg38vM4DGKoaf",
-	"Vw/dt0xjElmzO9+fvW9g2hvcTnTke0GFnl+GkuGILhqhhG7Hh20+y4spO6ufJsZiUMNttbaqYcqykRE7",
-	"PMKxne0a/JGC2ttz209P/3h4//79334uLv7ss/LmT+MMJ6/9OKxZGhk6p/ez+/t3s7t3s7tPd7O5/TeZ",
-	"3c3+3dWLrh2+jkEd/t/x4HAFeJB8OPS/XgP965voU3Ffd7065RlEVmBeASQxrzFJYoE/5bcMvaqV47mk",
-	"4Gp3mmMqVnmFWamw6aG8mR8iVaW1Z1JVx+cFI8uUf3HbRySj2zT6fXWvOuU90KHSNI5nbl4lNxMlOaxO",
-	"pl4rvC+rsr7yj5NcZ7Fs/hnC1VybeYysVbxrS8nBPJsh+iEysvoJyIjsnd1+2PvDNtf1p+r0kH++dAbL",
-	"39rXweBX2z/uGrU5U/g1c3ZXpg6Rkv8Xx73RJ0t9utTj8eFC9WP6fSR2GeEo1h8IZJryMqarDsoLpEYo",
-	"2o4olYuYSz79GjO9S1uGZrbZAglTpXCn5d0A5VLo3NcreL4Pazl0e7su066WT/tOiJjnCjzPbvMbT3dV",
-	"iCD+FwAA///uLJ3G/i0AAA==",
+	"H4sIAAAAAAAC/9RaXW/juBX9KwRboLuAxnYyfanfZpO2MDrYDZKZl+7MAy1eW5zKpJakkhqB/3txSX1Q",
+	"lmTJiZWZAvMwsSjy3MNzz+WHnmmsdpmSIK2hy2eaMc12YEG7v27KZyt+x2xyVz7EZxxMrEVmhZJ0Wbck",
+	"q1siDNHwRy40cCIkyZhNZjSiAhviHzSiku2ALuvBV5xGtHyJLq3OIaImTmDHcLA/a9jQJf3TvEY790/N",
+	"fMXp4RDR1S5jsf20z2AQrG9K7D6D8+CKYIxX45Wx4GOoLRueCbXq/lJAP2ecWRgPN3ftieDkJyE17EBa",
+	"lv58Rgh5MeDLA5BxOS49YCjYDRj7i+ICmgK/90/wt1hJC9L9l2VZKmKGkc2/GQzveeTQVcd+4CZFDyA5",
+	"YaR6bUYb+r00lrrnfjCSiDopPJ5iHi+Opuj3JJaiTQOI199UcHzvY0AVwp5RryiTKWm8mlb8vvjzcvB4",
+	"F6QPpFAy0WBzLQ3iW92WdJWivzya44QaA6t+x+F7yOMYjHkRNhQnXdK1UikweRpCwgwxfqxNnqZ7onPp",
+	"56yIppH/rvZplYG2hTWwzQZiC/yX/bj8+iiMxfi4MFnK9r86Dzv94m3Q9BBRwceoIaIpW0Nqhtp+9K1K",
+	"2/Pu+TsO8jUqiVTrbxA71Lco/paX3ykhLbq0FTuYkV/zNGXrFMhGaaIykARTA59tsBwY9PGN0jtm6ZJi",
+	"jrzDZ2joxYulfRfDG6uF3Lrhw2GfW3OaKrkFTSz815InYRPCwTKRugriBxRK4ujtjpuzcZTZidKWMMmJ",
+	"/30t5JZg8ensasU7ih0agtgUivW8OE7NjHz+vLolmYYNaA185qoY47/JdN9Lg1dSBwOVPcdKSuw+LB8u",
+	"gtCgHEXHlh4d6dsBAxnDONF5rGcUmg6RBYnSNcnCWKI2BWrjyAyjVLquC1/kSpKYGcAXwtBtgks6XGJs",
+	"UDCqxdOjiIE8gjZs9kXiusPCzowLrKaBMq3Zvlm12w7Cm6I+6QRB0zfwkHGeUFXqHm805xnjGrZMfrCD",
+	"AbkyHH0X9kBy4OMhjjXsLGFmEModNrqvkvIQFetf020Hda6nKUnYI5BdnlqRpUCqzDaYAEUvTvw2gT0x",
+	"icpTTqSyZA0kTpjcensalwrhEqDX0or8OE9nxRKsK9xyL4G+Z/I10WBUrmNwGS4bvmD/YogobBk4We+d",
+	"J4hgE4VMCGuIepJEaQ569kV+LlhKWIZ1TUjCyFY8Qt2iZaCxBmbPkcv3ULRDf96yrjlnvoMoiLZnCqse",
+	"OlYRRljxCJ74sqWrtfluDdqXTRwHf3ONcKqqqqo2BGbbWWPijZ+RHvkJaWELGpF9rBZLjHOB/bH0rjGP",
+	"rSrcRO87IEwD2WgAvwj5D+zJI0tzIBkT2teqmthg+VBTdFeawHHdM0JuUyDOJFDh33JjnT7dSgQVTWIm",
+	"MVerxHayxiZbkKA9S8hbqdUHgCUZ4TKOw1b8rk13lXaP6klwrLD0ie0xcyTHFRnDHMVa3l5y1GjPdBnH",
+	"jetilEd5qg8DbhSgqUb42jdx9+FqqcnJJ1VPDGF+HqPe2cEZlgDcW+7RguHFaf5iZi/mDwGCNon4Eq7U",
+	"XboJixsB+nDzQB4ss7khd2wL5MPdikYUV2ae1qvZwgHMQLJM0CV9P1vMrpEzZhNH17x5dLkFJ1gk1OHA",
+	"9Tr9J9ibutXRfv16sThr+zlKfMHJT0uALXP57V9+R5rvdkzvPd4ifdD2QkvBNFCmI8Qb58z1sOExV+/e",
+	"tXESNm8dgx1aTF3191S0mwfHH82gPELCiISnxqnXIQoncf4cHAcffKKl4FcEzZBv3e9hyOG59e/dQOsm",
+	"895z7cPXbomcDvz4SKMZvQfbOu8blOv3jqp3Or1GTQYx7nyD/RUWJe6VymyctMPzq6zJIry86l89+T7i",
+	"o8lH2ftdLvrDSfOq95dv417hFv7V9hWcPwwbWDDyC+ayfXo+oYU1j8qPZnP+HN4SjbCxRuDn5UP/ndeU",
+	"Rta+KxhW7xuE9gZ3JT16r6ww4GWsGU5I0QQpdDk/7OKsTKZir37aGKtGLdqODnkt086NrNjhFo7t3KnB",
+	"Hznovdu3/XT/j5v379//7efqGtI9q+8hDfZw8hKSw4blqaVLer24vn63uHq3uPp0tVi6f7PF1eLffSfj",
+	"R5uvQ3QM/++4cXgFeJB8PPS/vgb61zepT9Xt4eurU6kgsgb7BCCJfVIkUwJ/Ku88BqtWieclCXd0wzpl",
+	"xaovVBsZNn+uvxMYU6rqaM+0qp6PHSYuU+E18pCRTB7T5Lfng9WpPAMdW5qmYebiWXKxoiTH5ck8OJgf",
+	"UlVxrvzjiOssly0/ini115aXEButdl2SHO2zBaIfQpHND1ImdO/i9sPdZnZRNyzV+XP5MdUZLn9prqPR",
+	"r3Z/ajbp4UzFa0F2n1LHlJL/F+Le6AOqobo0wPj4QvVj8j6Ru0ywFRueCHSa+jKmLw/qC6TWVHRtURoX",
+	"MS/5EG1KedexjFW2TYDEuda40gpugMpS6OkbLHghh0caunxcL6tdHR8anihiARW4n03KG09/VYgg/hcA",
+	"AP//hTLRi4wuAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/api/api.gen.go
+++ b/pkg/api/api.gen.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -145,6 +146,20 @@ type PhaseReference struct {
 	Order *Incremental `json:"order,omitempty"`
 }
 
+// ResponseData Wraps the retuned data in an object.
+// See: https://github.com/SovereignCloudStack/status-page-openapi/issues/6
+type ResponseData struct {
+	Content *ResponseData_Content `json:"content,omitempty"`
+}
+
+// ResponseData_Content defines model for ResponseData.Content.
+type ResponseData_Content struct {
+	union json.RawMessage
+}
+
+// Success An operation was successful.
+type Success = bool
+
 // ComponentIdPathParameter Identification for objects. UUID preferred.
 type ComponentIdPathParameter = Id
 
@@ -157,14 +172,9 @@ type IncidentIdPathParameter = Id
 // IncidentUpdateIdPathParameter Positive and incrementing number for ordering and identfication of e.g. sub resources.
 type IncidentUpdateIdPathParameter = Incremental
 
-// IdResponse Identification for objects. UUID preferred.
-type IdResponse = Id
-
-// IncrementalResponse Positive and incrementing number for ordering and identfication of e.g. sub resources.
-type IncrementalResponse = Incremental
-
-// SuccessResponse defines model for SuccessResponse.
-type SuccessResponse = bool
+// Response Wraps the retuned data in an object.
+// See: https://github.com/SovereignCloudStack/status-page-openapi/issues/6
+type Response = ResponseData
 
 // ComponentRequest defines model for ComponentRequest.
 type ComponentRequest = Component
@@ -220,6 +230,94 @@ type UpdateIncidentUpdateJSONRequestBody = IncidentUpdate
 
 // CreatePhaseListJSONRequestBody defines body for CreatePhaseList for application/json ContentType.
 type CreatePhaseListJSONRequestBody = PhaseList
+
+// AsSuccess returns the union data inside the ResponseData_Content as a Success
+func (t ResponseData_Content) AsSuccess() (Success, error) {
+	var body Success
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromSuccess overwrites any union data inside the ResponseData_Content as the provided Success
+func (t *ResponseData_Content) FromSuccess(v Success) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeSuccess performs a merge with any union data inside the ResponseData_Content, using the provided Success
+func (t *ResponseData_Content) MergeSuccess(v Success) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JsonMerge(b, t.union)
+	t.union = merged
+	return err
+}
+
+// AsId returns the union data inside the ResponseData_Content as a Id
+func (t ResponseData_Content) AsId() (Id, error) {
+	var body Id
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromId overwrites any union data inside the ResponseData_Content as the provided Id
+func (t *ResponseData_Content) FromId(v Id) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeId performs a merge with any union data inside the ResponseData_Content, using the provided Id
+func (t *ResponseData_Content) MergeId(v Id) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JsonMerge(b, t.union)
+	t.union = merged
+	return err
+}
+
+// AsIncremental returns the union data inside the ResponseData_Content as a Incremental
+func (t ResponseData_Content) AsIncremental() (Incremental, error) {
+	var body Incremental
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromIncremental overwrites any union data inside the ResponseData_Content as the provided Incremental
+func (t *ResponseData_Content) FromIncremental(v Incremental) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeIncremental performs a merge with any union data inside the ResponseData_Content, using the provided Incremental
+func (t *ResponseData_Content) MergeIncremental(v Incremental) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JsonMerge(b, t.union)
+	t.union = merged
+	return err
+}
+
+func (t ResponseData_Content) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *ResponseData_Content) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
@@ -697,39 +795,40 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/9RaXW/juBX9KwRboLuAxnYyfanfZpO2MDrYDZKZl+7MAy1eW5zKpJakkhqB/3txSX1Q",
-	"lmTJiZWZAvMwsSjy3MNzz+WHnmmsdpmSIK2hy2eaMc12YEG7v27KZyt+x2xyVz7EZxxMrEVmhZJ0Wbck",
-	"q1siDNHwRy40cCIkyZhNZjSiAhviHzSiku2ALuvBV5xGtHyJLq3OIaImTmDHcLA/a9jQJf3TvEY790/N",
-	"fMXp4RDR1S5jsf20z2AQrG9K7D6D8+CKYIxX45Wx4GOoLRueCbXq/lJAP2ecWRgPN3ftieDkJyE17EBa",
-	"lv58Rgh5MeDLA5BxOS49YCjYDRj7i+ICmgK/90/wt1hJC9L9l2VZKmKGkc2/GQzveeTQVcd+4CZFDyA5",
-	"YaR6bUYb+r00lrrnfjCSiDopPJ5iHi+Opuj3JJaiTQOI199UcHzvY0AVwp5RryiTKWm8mlb8vvjzcvB4",
-	"F6QPpFAy0WBzLQ3iW92WdJWivzya44QaA6t+x+F7yOMYjHkRNhQnXdK1UikweRpCwgwxfqxNnqZ7onPp",
-	"56yIppH/rvZplYG2hTWwzQZiC/yX/bj8+iiMxfi4MFnK9r86Dzv94m3Q9BBRwceoIaIpW0Nqhtp+9K1K",
-	"2/Pu+TsO8jUqiVTrbxA71Lco/paX3ykhLbq0FTuYkV/zNGXrFMhGaaIykARTA59tsBwY9PGN0jtm6ZJi",
-	"jrzDZ2joxYulfRfDG6uF3Lrhw2GfW3OaKrkFTSz815InYRPCwTKRugriBxRK4ujtjpuzcZTZidKWMMmJ",
-	"/30t5JZg8ensasU7ih0agtgUivW8OE7NjHz+vLolmYYNaA185qoY47/JdN9Lg1dSBwOVPcdKSuw+LB8u",
-	"gtCgHEXHlh4d6dsBAxnDONF5rGcUmg6RBYnSNcnCWKI2BWrjyAyjVLquC1/kSpKYGcAXwtBtgks6XGJs",
-	"UDCqxdOjiIE8gjZs9kXiusPCzowLrKaBMq3Zvlm12w7Cm6I+6QRB0zfwkHGeUFXqHm805xnjGrZMfrCD",
-	"AbkyHH0X9kBy4OMhjjXsLGFmEModNrqvkvIQFetf020Hda6nKUnYI5BdnlqRpUCqzDaYAEUvTvw2gT0x",
-	"icpTTqSyZA0kTpjcensalwrhEqDX0or8OE9nxRKsK9xyL4G+Z/I10WBUrmNwGS4bvmD/YogobBk4We+d",
-	"J4hgE4VMCGuIepJEaQ569kV+LlhKWIZ1TUjCyFY8Qt2iZaCxBmbPkcv3ULRDf96yrjlnvoMoiLZnCqse",
-	"OlYRRljxCJ74sqWrtfluDdqXTRwHf3ONcKqqqqo2BGbbWWPijZ+RHvkJaWELGpF9rBZLjHOB/bH0rjGP",
-	"rSrcRO87IEwD2WgAvwj5D+zJI0tzIBkT2teqmthg+VBTdFeawHHdM0JuUyDOJFDh33JjnT7dSgQVTWIm",
-	"MVerxHayxiZbkKA9S8hbqdUHgCUZ4TKOw1b8rk13lXaP6klwrLD0ie0xcyTHFRnDHMVa3l5y1GjPdBnH",
-	"jetilEd5qg8DbhSgqUb42jdx9+FqqcnJJ1VPDGF+HqPe2cEZlgDcW+7RguHFaf5iZi/mDwGCNon4Eq7U",
-	"XboJixsB+nDzQB4ss7khd2wL5MPdikYUV2ae1qvZwgHMQLJM0CV9P1vMrpEzZhNH17x5dLkFJ1gk1OHA",
-	"9Tr9J9ibutXRfv16sThr+zlKfMHJT0uALXP57V9+R5rvdkzvPd4ifdD2QkvBNFCmI8Qb58z1sOExV+/e",
-	"tXESNm8dgx1aTF3191S0mwfHH82gPELCiISnxqnXIQoncf4cHAcffKKl4FcEzZBv3e9hyOG59e/dQOsm",
-	"895z7cPXbomcDvz4SKMZvQfbOu8blOv3jqp3Or1GTQYx7nyD/RUWJe6VymyctMPzq6zJIry86l89+T7i",
-	"o8lH2ftdLvrDSfOq95dv417hFv7V9hWcPwwbWDDyC+ayfXo+oYU1j8qPZnP+HN4SjbCxRuDn5UP/ndeU",
-	"Rta+KxhW7xuE9gZ3JT16r6ww4GWsGU5I0QQpdDk/7OKsTKZir37aGKtGLdqODnkt086NrNjhFo7t3KnB",
-	"Hznovdu3/XT/j5v379//7efqGtI9q+8hDfZw8hKSw4blqaVLer24vn63uHq3uPp0tVi6f7PF1eLffSfj",
-	"R5uvQ3QM/++4cXgFeJB8PPS/vgb61zepT9Xt4eurU6kgsgb7BCCJfVIkUwJ/Ku88BqtWieclCXd0wzpl",
-	"xaovVBsZNn+uvxMYU6rqaM+0qp6PHSYuU+E18pCRTB7T5Lfng9WpPAMdW5qmYebiWXKxoiTH5ck8OJgf",
-	"UlVxrvzjiOssly0/ini115aXEButdl2SHO2zBaIfQpHND1ImdO/i9sPdZnZRNyzV+XP5MdUZLn9prqPR",
-	"r3Z/ajbp4UzFa0F2n1LHlJL/F+Le6AOqobo0wPj4QvVj8j6Ru0ywFRueCHSa+jKmLw/qC6TWVHRtURoX",
-	"MS/5EG1KedexjFW2TYDEuda40gpugMpS6OkbLHghh0caunxcL6tdHR8anihiARW4n03KG09/VYgg/hcA",
-	"AP//hTLRi4wuAAA=",
+	"H4sIAAAAAAAC/9Ra32/juBH+Vwi2QO8Ar+VkiwL1217SHowuboNkFwV6mwdaHFvck0gdSSU1Av/vxZD6",
+	"QVlSJCd2bgvsw8aiyJmP33xDzuiJxirLlQRpDV0+0ZxploEF7f66qp6t+A2zyU31EJ9xMLEWuRVK0mUz",
+	"kqyuiTBEw++F0MCJkCRnNpnTGRU4EP+gMypZBnTZLL7idEarl+jS6gJm1MQJZAwX+7OGDV3SP0WNtZF/",
+	"aqIVp/v9jK6ynMX28y6HUWP9UGJ3ORxnrgjWeLW9MhZ8CrTVwCNNrac/laFfcs4sTDe3cOOJ4OQHITVk",
+	"IC1LfzzChaJc8OUOyLhal+7RFZwGjP1JcQFtgt/6J/hbrKQF6f7L8jwVMUPPom8G3XuauHQ9sV+4DdEd",
+	"SE4YqV+b0xZ/T21LM/OwMZKIJii8PeU+ntyact5nbSnHtAzx/DuXOX72KUaVxJ5TzyiTK2k8m27LP05m",
+	"XDXhNbOsz7SfQYJmKamsIBuliSniGIzZFClROWi3rvHWlvO2mO9UX+NIWwYF22wgtsB/2k1j1kdhLG4U",
+	"FyZP2e4XF73Pv3gdDN3PqOBTtGhGU7aG1IyN/ehHVQHvdeNXXOR+RpHfdEnV+hvEzupr3PaOit0oIS3q",
+	"kxUZzMkvRZqydeoBVjlIgqTAZxsUQoMKtlE6Y5YuKbLjHT5DKStfrISrXN5YLeTWLR8ue2jFB5IquQVN",
+	"LPzXkkdhE8LBMpE67fQLCiVx9e7E7d044HSitCVMcuJ/Xwu5JSi7vVOteI/MYyiITclrj4vD1MzJly+r",
+	"a5Jr2IDWwOdOvxn/JNPdIAyeST0I1MIUKylx+lA4nQdhaDqIDsVsdsBvZxjIGKaRztt6hMT2kCwIlL5N",
+	"FsYStSmtNg7M0EulG0X8KleSxMwAvhC6bhM8zGBy3SBhVAenBxEDeQBt2PyrxIxrITPTHGtgoExrtmvn",
+	"q66C8Dapn1WCYOgbaMg0Tahz1IA2muOEcQ1bJj/YUYdcApr9IeiB5MCnmzhVsPOEmVFTbnDQbR2U+1l5",
+	"8jP9ctDEepqShD0AyYrUijwFUke2wQAoZ3HktwnsiElUkXIilSVrIHHC5NbL07RQCE+Tg5JWxsdxPCsP",
+	"H33uVqdo1D1TrDHVq0LH4CJctnTB/sUQUcoycLLeOU0QwfUBkRDWEPUoidIc9Pyr/FKilLAc85qQhJGt",
+	"eIBmREdAYw3MHkOXP4LRzvrjbgjtPfMTzAJvB7awnqHnFGGEFQ/gga9GulxbZGvQPm3iOvibG4RbVWdV",
+	"tSEw385bG2/8jgzQT0gLW9Bo2cf6sMQ4FzgfS29a+9jJwm3r/QSEaSAbDeAPIb/BjjywtACSM6F9rmqA",
+	"DY4PDUQ3lQgc5j0j5DYF4kQCGf6tMNbx051EkNEkZhJjtQ5sR2scsnVHX4cS4lZx9Q5gSSaojMOw478b",
+	"05+l3aNmExwqLH1kO4wcyfFExjBGMZd3jxyNtUeqjMPGTTFJozzU+xE1CqypV7gf2rjb8LTUxuSzajaG",
+	"ML+Ps8HdwR2WANxL7sGB4cVh/mJkT6YPgQV9ILbucB0I/61ZbpxOa7CFBE44s8ypsCwP1BWrE2tzs4yi",
+	"rbBJsZ7HKovu1ANoEFt5laqC31kW/xYZy2xh3uVsC+/wpsJyEQljCjDR3/q0vLmnKgmfNnT56/OQ3Pnr",
+	"Jd3PJhwAjkD3vvfgXK3Wlxrr2y15ZCa49gYitFYqBSb93RlvTE72hMULGb27uiN3Di1yw7ZAPtys6Izi",
+	"CdkvcTFfOKJ4EOmSvp8v5peIILOJMylqF0+34HGs7MJ7E/0Z7FUz6qBicLlYHFUsmCQCQe2pIwQdkf/0",
+	"L18ZKLKM6Z23t5QxTD+htKMcKdPj4pXLkM2yYaFtsIbQqsVFnULcvoPUxfBM5bi6XnLgkrePMCLhsVV1",
+	"28/CLYyegnL03lMuBX8uazt87X4PHQ7r5gMB1AyJBuvq+/t+grzIbW9lp9A4ytLv1B1PTJNDLDYiDi63",
+	"eCLgnp7MxknXOX/EPZt/p6f6y0Hyrh7sOdLc1xZQDZ6VquZW/zZaFRZOXi1WQdVnXK6ClV+wid1q/dkE",
+	"q12YP9jL6CnsSU0QrZbbx4XBcIftLLLVbUmMk/YNfHqDlswAzWvpC3CZKn5nhOgMkXMC/esDqwqfsiLy",
+	"vBDWgzp4HZTSLdNOfazI8KLMMleb+b0AvXO34x9u/3n1/v37v/9Ytznds6bPaXCGZ5ucHDasSC1d0svF",
+	"5eW7xcW7xcXni8XS/ZsvLhb/Geo/HFxx8UTeNv8feD17hfEg+XTT//oa0+/fJB/V3cnXZ6OKQWQN9hFA",
+	"EvuoSK4E/lR1lkazVGXPSyLtoIN7vgzVtGtb8RU9NV8hTElNja9HKtTApxTnSkthd3pMP87uzNmb8qPZ",
+	"qCowT01F50Hm5MHx+iQkp0VGFLQ7xuhUVuu/H1YdparVRxav1taqtbPRKuvj4mRdLS36LqjY/sDlbGpd",
+	"dpRch7gPuHGiRk/Vp1lHqPqpkZ5NfrX/w7XzlFpqQEuUhwg6JXX8vyD2Rt9hjeWhEcSnJ6bvE/czicop",
+	"r1rjO4Da0rS0hgKgacN19qDvCtJqZ73ky9Bz8rrxZSqlbQIkLrTGI1XQR6tSn4dvNMGFGB6Q5/R+nS1X",
+	"Bf7jJTWpmsW+y4or/y8AAP//1jcFnsEuAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/api/api.gen.go
+++ b/pkg/api/api.gen.go
@@ -23,7 +23,7 @@ import (
 type Component struct {
 	AffectedBy  *[]Id   `json:"affectedBy,omitempty"`
 	DisplayName *string `json:"displayName,omitempty"`
-	Id          *string `json:"id,omitempty"`
+	Id          *Id     `json:"id,omitempty"`
 	Labels      *Labels `json:"labels,omitempty"`
 }
 
@@ -36,7 +36,7 @@ type Incident struct {
 	BeganAt     *time.Time          `json:"beganAt,omitempty"`
 	Description *string             `json:"description,omitempty"`
 	EndedAt     *time.Time          `json:"endedAt"`
-	Id          *string             `json:"id,omitempty"`
+	Id          *Id                 `json:"id,omitempty"`
 	ImpactType  *IncidentImpactType `json:"impactType,omitempty"`
 	Phase       *IncidentPhase      `json:"phase,omitempty"`
 	Title       *string             `json:"title,omitempty"`
@@ -110,13 +110,13 @@ type ServerInterface interface {
 	CreateComponent(ctx echo.Context) error
 	// Delete a component
 	// (DELETE /components/{componentId})
-	DeleteComponent(ctx echo.Context, componentId string) error
+	DeleteComponent(ctx echo.Context, componentId Id) error
 	// Get specific component by id
 	// (GET /components/{componentId})
-	GetComponent(ctx echo.Context, componentId string) error
+	GetComponent(ctx echo.Context, componentId Id) error
 	// Fully or partially change a component
 	// (PATCH /components/{componentId})
-	UpdateComponent(ctx echo.Context, componentId string) error
+	UpdateComponent(ctx echo.Context, componentId Id) error
 
 	// (GET /impacttypes)
 	GetImpacttypes(ctx echo.Context) error
@@ -134,13 +134,13 @@ type ServerInterface interface {
 	CreateIncident(ctx echo.Context) error
 	// Delete a incident
 	// (DELETE /incidents/{incidentId})
-	DeleteIncident(ctx echo.Context, incidentId string) error
+	DeleteIncident(ctx echo.Context, incidentId Id) error
 	// Get specific incident by id
 	// (GET /incidents/{incidentId})
-	GetIncident(ctx echo.Context, incidentId string) error
+	GetIncident(ctx echo.Context, incidentId Id) error
 	// Fully or partially change a incident
 	// (PATCH /incidents/{incidentId})
-	UpdateIncident(ctx echo.Context, incidentId string) error
+	UpdateIncident(ctx echo.Context, incidentId Id) error
 
 	// (GET /phases)
 	GetPhases(ctx echo.Context) error
@@ -176,7 +176,7 @@ func (w *ServerInterfaceWrapper) CreateComponent(ctx echo.Context) error {
 func (w *ServerInterfaceWrapper) DeleteComponent(ctx echo.Context) error {
 	var err error
 	// ------------- Path parameter "componentId" -------------
-	var componentId string
+	var componentId Id
 
 	err = runtime.BindStyledParameterWithLocation("simple", false, "componentId", runtime.ParamLocationPath, ctx.Param("componentId"), &componentId)
 	if err != nil {
@@ -192,7 +192,7 @@ func (w *ServerInterfaceWrapper) DeleteComponent(ctx echo.Context) error {
 func (w *ServerInterfaceWrapper) GetComponent(ctx echo.Context) error {
 	var err error
 	// ------------- Path parameter "componentId" -------------
-	var componentId string
+	var componentId Id
 
 	err = runtime.BindStyledParameterWithLocation("simple", false, "componentId", runtime.ParamLocationPath, ctx.Param("componentId"), &componentId)
 	if err != nil {
@@ -208,7 +208,7 @@ func (w *ServerInterfaceWrapper) GetComponent(ctx echo.Context) error {
 func (w *ServerInterfaceWrapper) UpdateComponent(ctx echo.Context) error {
 	var err error
 	// ------------- Path parameter "componentId" -------------
-	var componentId string
+	var componentId Id
 
 	err = runtime.BindStyledParameterWithLocation("simple", false, "componentId", runtime.ParamLocationPath, ctx.Param("componentId"), &componentId)
 	if err != nil {
@@ -292,7 +292,7 @@ func (w *ServerInterfaceWrapper) CreateIncident(ctx echo.Context) error {
 func (w *ServerInterfaceWrapper) DeleteIncident(ctx echo.Context) error {
 	var err error
 	// ------------- Path parameter "incidentId" -------------
-	var incidentId string
+	var incidentId Id
 
 	err = runtime.BindStyledParameterWithLocation("simple", false, "incidentId", runtime.ParamLocationPath, ctx.Param("incidentId"), &incidentId)
 	if err != nil {
@@ -308,7 +308,7 @@ func (w *ServerInterfaceWrapper) DeleteIncident(ctx echo.Context) error {
 func (w *ServerInterfaceWrapper) GetIncident(ctx echo.Context) error {
 	var err error
 	// ------------- Path parameter "incidentId" -------------
-	var incidentId string
+	var incidentId Id
 
 	err = runtime.BindStyledParameterWithLocation("simple", false, "incidentId", runtime.ParamLocationPath, ctx.Param("incidentId"), &incidentId)
 	if err != nil {
@@ -324,7 +324,7 @@ func (w *ServerInterfaceWrapper) GetIncident(ctx echo.Context) error {
 func (w *ServerInterfaceWrapper) UpdateIncident(ctx echo.Context) error {
 	var err error
 	// ------------- Path parameter "incidentId" -------------
-	var incidentId string
+	var incidentId Id
 
 	err = runtime.BindStyledParameterWithLocation("simple", false, "incidentId", runtime.ParamLocationPath, ctx.Param("incidentId"), &incidentId)
 	if err != nil {
@@ -403,24 +403,24 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/8xYzY7bNhB+FYLtoQW0luztpbptnCYwGjTGOr002AMtjmwGEsUlqbaCoXcvSNrWr2Xt",
-	"ru0U8EGiRjPffPNr7XCUpSLjwLXC4Q5LeM5B6XcZZWAP5ofHj+6JOYsyroHbSyJEwiKiWcb9byrj5kxF",
-	"W0iJufpRQoxD/INfGfHdU+UfFeOyLD1MQUWSCaMIh3gFnCKCokrGwwseMXoFIAe9p3FwxCoZD0tQIuPK",
-	"8bOgj/vbywGifVAe0D42SILOJVcG1+K9YWaVRxEo9SoguhCAQ7zOsgQIHza8JQopZyvOk6RAMueWkT3y",
-	"Rr6YGyEzAVLvU4nEMUQa6LvC3DENqRpDhXfASKQkhbmnTImEFH+QFGouKC0Z35jnjLpUJvQzTwocapmD",
-	"1xVLyBqSsxA+OSkX+OecSaA4/GpsPB11ZutvELkkpb2Ijjl2ghT1RkbWsCH8waqPM5kSjUNMiYY7zVLA",
-	"Pb43QtwDGDgFOqCQ50lC1gmcJHdkDFgqSKS/2ONxZbqo3ig9LLZEjX51aYUNfUwn/amTC+PlC8KxV/2n",
-	"fa8bmpFZ0/VtKIuWB6dPSuzhdLItkkD0YGA7KjX8q3tstRyzUl5Nf5+bn44FRyhlJvdIsmzg61pv6jBm",
-	"GY8zK+uCiFfzFVpponOFlmQD6GG5wB7+G6Ry/Ws6CYymTAAnguEQ30+CyQx7WBC9tVb95gzcgHXY4LJd",
-	"09Q0/gh6Xkm1hsAsCF7UdEel1rw+/FpZ1WnSn393pyJTPeDnNiyVQq8254tTOBqrgN/ZA8oOB9PTmvZy",
-	"fm1a2rmRpymRxREhIojDP/WxX3r16Pi74/WClsYchQRcojc9fm/P6x4LIkkKGqTC4dcdZoY1kwGmmdlB",
-	"gmu6cT27XevqjMxjJTz1Z8MwE+2Z3aTDwW9vQGcT83u4ef1l0OZ2nZ2PoJESELGYRRVDaF0gZqejIDra",
-	"dplyTfGGZF2+xN6cWB/s3pZJJIjUjJibaEv4ppVrpuzcaDaODXbFRU3sFm2xfw+4RH+saexE76L/NOrQ",
-	"y/KKjdSFEGlnqRlTf1ftXiNaaYOc83XD2lz2l82L2bpir+U9dO0hDBfAUahDTOvPpCZSoyxGZtVCsZFE",
-	"OkPPOcgCxZlEPz1+mN/f3//6M/Ycp/ZRRaoyCgb5pBCTPDE73SyYze6C6V0w/TINQvubBNPgL+yN2vtK",
-	"r43+N07fgh04HY/8l7cgf7plFxrde9rzK2HK5kKVYue608HiKyZL+9PJNVtO/UtJVUD+7nA5anGrOTui",
-	"1xw1/2/WNlZLj3N94zv4ePXvZsMr28GZkRvbzYi6eFVddV1rVpr9EDI4p5ZO4pbdsfrgMnY9y3uwL/M6",
-	"9tetZZeBfYUIN5rnYSi4YE6syf8CAAD//1+2pLOiFwAA",
+	"H4sIAAAAAAAC/8xYTW/jNhD9KwTbQwtoIznppbplvd2F0UVrxNtLFznQ4sjmQiIZkmprGPrvBUnb+rSs",
+	"OHY2QA6WNJp582b4ZqItTkQuBQduNI63WMFTAdq8F5SBuzHdP37wT+y9RHAD3P0kUmYsIYYJHn7Tgtt7",
+	"OllDTuyvHxWkOMY/hFWQ0D/V4cExLssywBR0opi0jnCMF8ApIiipbAI84wmjVwCy93scB0essgmwAi0F",
+	"156fGX3YXV4OEO2Dco92tUEKTKG4trhmHywziyJJQOuzgJiNBBzjpRAZED4ceE000j5WWmTZBqmCO0Z2",
+	"yBv9Yi+kEhKU2bUSSVNIDND3G3vFDOR6DBXBHiNRimzsNWVaZmTzB8mhloI2ivGVfc7oOL8ZWUJ2EsNn",
+	"b1VWQMTyGyS+J2kvgENLHeFAv5CAJawIv3fuU6FyYnCMKTHwzrAccNAF1KhoD2DgFOiAQ15kGVlmgGOj",
+	"CgjOp5zlkiTmi3t93LGcVW+UAZZroke/OnfGlj9msv5WKaRN8xn12Ln+y73XrU1vk3QzGWqa+T7Foxa7",
+	"4J3mShQQM1jHjksD/5meWE7lngqmgOL4q7cKav4fe9L8fDhNhFJmW41k8wa+bvSmDxuW8VQ4W18yvJgu",
+	"0MIQU2g0JytA9/MZDvA/oLRXp8lNZD0JCZxIhmN8dxPd3OIAS2LWLmrYnHArcAlbXE4T7RHGn8BMK6uW",
+	"xN9G0bMkdVQjTeujrdVDHQn+83d/VwrdA37qylI5DGpTfHMMR2PQh50pX3Y4mBz3tLMLa7PQTYUiz4na",
+	"HBAigjj8Wx/qZVCvTrg9/J7R0oajkIFv9GbGH9z9esaSKJKDAaVx/HWLmWXNdoDVLjcmcM03rne3F7Rn",
+	"TObH/vYYpqY9opv8+HzaC8/JTn0TeV9/GXTdX6frExikJSQsZUlFGVpuEHNDRhKTrLvUedn8nuxd/lS+",
+	"uPU+ukVOKCSJMozYi2RN+KrVjfak+tlttWpQSGc1s9dQ0v5F4RKSWvPYqd5F//WoQy/LK2qvLyEyPlKz",
+	"puG2Ws5GqG+DnNMHibW5POMc9bF1RTXmPXTtIAwfgINRh5jWf5eGKINEiux2hlJriYxATwWoDUqFQj89",
+	"fJze3d39+jMOPKfuUUWqtg4G+aSQkiKza+BtdHv7Lpq8iyZfJlHs/m6iSfQ3DkatimXQRv8bpy/BDpyO",
+	"R/7LS5A/vqYKjdae9kDLmHa9ULXYKXXaRzxjsrS/pVxTcuqfTqoDFG73P0fterVkR2jNwfPb3fRYrV9O",
+	"CclbSPrqn9qGt7x9diOXvO/H3MUP4lU3vObhdB9XBkfb3Fu8pqBWH3HGbnRFD/Z5Ucd+3iZ3GdhXqHBD",
+	"b/dzxBfzxoX8PwAA///E7Ukd5hcAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/api/api.gen.go
+++ b/pkg/api/api.gen.go
@@ -391,22 +391,22 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/9RYUY/iNhD+K5bbh1bKQmD70rzd0d4J9dSi7vWlp30Y4gn4lNg+22kbIf57ZRtIQrIQ",
-	"urcslXhInMnMN998MxmxoakslBQorKHJhpp0jQX4y9n+gbtRWirUlqN/BFmGqUX2tnJ33GLhj7/VmNGE",
-	"fjOufY53DsdzRrcRtZVCmlDQGip3z7hROVS/QoHOwe6xsZqLlXvOWe9xDkvMz4b8EKy2dVy5/IypdR7m",
-	"/Y7nIuXsRMrmmfkucQXijXefSV2ApQllYPHO8gJp1AXE0KSaK8ul6AWMgiE74VCUeQ7LHGlidYnRYIZ5",
-	"oSC1H/3xmUR3lM3rN7YRVWswg19deGNHF7d5vxBK5bK6gP6d6z/8e91S9Gqim8kpjSz2KT5psQve0VKq",
-	"EezJsnVcWvzH9sTaRlTjl5JrZDT5FKyihv/HnjQ/HJoHGONOWZAvWvi60ds+XFguMultQ8now+yBPFiw",
-	"pSELWCF5s5jTiP6F2njp0skodp6kQgGK04Tej+LRlEZUgV37qOP2JFqhT9jhAgfSdSx9j3ZWW7nkjZLC",
-	"BNjTOPbsSmF3LQxK5Tz1r48/m9BCQSGDhVRPwa6GjvuT/vZLOFXS9ICf+bLUDkPt0Ni3klUXIR8IeBv0",
-	"0aJoclGgY7l1Mg45Ma9EUxYF6OpwSoAI/JukDUBRs8rjzeF6zrYuHMMcQ8O0mfvJnzeZU6ChQIva0OTT",
-	"hnKHxSnJjTz/MaEN37TZJWEOPp3i4zNVtfO3lDJHEE+qpElXSI9Ak6rofAPcNA2DJXqWnfdoiVGY8oyn",
-	"NUNkWRHuv7EKbLruMhWG7xXJunorv7gu35V5XhGpiQJtObibdA1idSRV19VhX3AxTg7vecPsGtO7fzn5",
-	"GmO84fFlit8H/TYGeqg1sQFSu/jjTb05DhjpLRbP9yc/Jr2/PS+m9RVnvuihcwfxdCcdjDrEtSM/WNCW",
-	"yIy41ZJkzpJYSb6UqCuSSU2++/3d7P7+/sfvaRQ4949q0o1zcJJvhhmUudthp/F0ehdP7uLJx0mc+N8o",
-	"nsR/0mjQnruNjtH/LNhzsKNgw5H/8Bzkj9ccZ4OH2PF3NOfGa6GW2Lkxt4/4skPuZkZbjafZiOPN/nLQ",
-	"otogbcBMO3j+36ypvCHDc/PpljkYqszLVtR9MgM31KsRde3ufdX1tN3I/t+ok5/TRbC45hCv//Uauo6W",
-	"PdgXZRP7f6vx14H9Cgpoze79ty0Ue+Qh/RsAAP//ok5VGt8WAAA=",
+	"H4sIAAAAAAAC/9RYUY/iNhD+K5bbh1bKQmD70rzd0d4J9dRD3etLT/swxBPwKbF9ttM2Qvz3yjaQhGQh",
+	"dHfZPYmHxJnMfPPNN5MRG5rKQkmBwhqabKhJ11iAv5ztH7gbpaVCbTn6R5BlmFpkbyt3xy0W/vh7jRlN",
+	"6Hfj2ud453A8Z3QbUVsppAkFraFy94wblUP1OxToHOweG6u5WLnnnLljjcA+iryiidUlRl2zHJaYn4Xw",
+	"IVhttxHV+LXkGhlNPrsY9wefcvkFU+t8zlkvorlIOTtBinkkI0tcgXjj3WdSF2BpQhlYvLG8QNqTO0OT",
+	"aq4sl6IXMAqG7IRDUeY5LHN8kNyBNeCFgtR+8sdnEt9ROK/f2EZUrcEMfnXhjR193Ob90imVy/KCcuxc",
+	"/+nf65ZmoGq6uZ1S0WKf9IMWOzgdtaUawZ4sbMelxX9tT6yjxLxV1PDfl+aHQ8MBY9xpD/JFC183etuH",
+	"C8tFJr1tKCK9m92ROwu2NGQBKyRvFnMa0b9RGy9uOhnFzpNUKEBxmtDbUTya0ogqsGsfddyeZiv0CTtc",
+	"4EC6nqbv0c5qK5e8UVKYAHsax55dKeyuyUGpnKf+9fEXE5osaGawtOpJ2lXVcQfTj7+FUyVND/iZL0vt",
+	"MNQOjX0rWXUR8oGAt0EfLYomFwU6llsn45AT80o0ZVGArg6nBIjAf0jaABQ1qzzeHK7nbOvCMcwxNEyb",
+	"uV/8eZM5BRoKtKgNTT5vKHdYnJLcUPQfJNrwTZtdEkbgwyneP1JVO39LKXME8aBKmnSF9Ag0qYrON8Cr",
+	"pmGwRM+y8x4tMQpTnvG0ZogsK8L9V1iBTdddpsLwvSJZV2/lZ9fluzLPKyI1UaAtB3eTrkGsjqTqujps",
+	"EC7GyeE9b5hdY3r3rytPMcYbHp+n+H3QX8dAD7UmNkBqF3+8qXfJASO9xeL5/uTHpPe358W0vuDMFz10",
+	"7iCe7qSDUYe4duQ7C9oSmRG3WpLMWRIrydcSdUUyqckPf7yb3d7e/vwjjQLn/lFNunEOTvLNMIMydzvs",
+	"NJ5Ob+LJTTz5NIkT/xvFk/gvGg3ac7fRMfpfBXsMdhRsOPKfHoP8/prjbPAQO/6O5tx4LdQSOzfm9hGf",
+	"d8i9mtFW42k24nizvxy0qDZIGzDTDp6/mTWVN2R4bj69Zg6GKvOyFXWfzMAN9WpEXbt7X3Q9bTey/3/q",
+	"5Od0ESyuOcTr/8GGrqNlD/ZF2cT+/2r8NLBfQAGt2b3/toVijzyk/wIAAP//ugwDgiMXAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/api/api.gen.go
+++ b/pkg/api/api.gen.go
@@ -90,6 +90,9 @@ type ServerInterface interface {
 	// Create a new component
 	// (POST /components)
 	CreateComponent(ctx echo.Context) error
+	// Delete a component
+	// (DELETE /components/{componentId})
+	DeleteComponent(ctx echo.Context, componentId string) error
 	// Get specific component by id
 	// (GET /components/{componentId})
 	GetComponent(ctx echo.Context, componentId string) error
@@ -99,12 +102,18 @@ type ServerInterface interface {
 	// Create a new impact type
 	// (POST /impacttypes)
 	CreateImpactType(ctx echo.Context) error
+	// Delete a impact type
+	// (DELETE /impacttypes/{impactType})
+	DeleteImpactType(ctx echo.Context, impactType IncidentImpactType) error
 	// Get list of incidents
 	// (GET /incidents)
 	GetIncidents(ctx echo.Context, params GetIncidentsParams) error
 	// Create a new incident
 	// (POST /incidents)
 	CreateIncident(ctx echo.Context) error
+	// Delete a incident
+	// (DELETE /incidents/{incidentId})
+	DeleteIncident(ctx echo.Context, incidentId string) error
 	// Get specific incident by id
 	// (GET /incidents/{incidentId})
 	GetIncident(ctx echo.Context, incidentId string) error
@@ -136,6 +145,22 @@ func (w *ServerInterfaceWrapper) CreateComponent(ctx echo.Context) error {
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.CreateComponent(ctx)
+	return err
+}
+
+// DeleteComponent converts echo context to params.
+func (w *ServerInterfaceWrapper) DeleteComponent(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "componentId" -------------
+	var componentId string
+
+	err = runtime.BindStyledParameterWithLocation("simple", false, "componentId", runtime.ParamLocationPath, ctx.Param("componentId"), &componentId)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter componentId: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.DeleteComponent(ctx, componentId)
 	return err
 }
 
@@ -173,6 +198,22 @@ func (w *ServerInterfaceWrapper) CreateImpactType(ctx echo.Context) error {
 	return err
 }
 
+// DeleteImpactType converts echo context to params.
+func (w *ServerInterfaceWrapper) DeleteImpactType(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "impactType" -------------
+	var impactType IncidentImpactType
+
+	err = runtime.BindStyledParameterWithLocation("simple", false, "impactType", runtime.ParamLocationPath, ctx.Param("impactType"), &impactType)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter impactType: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.DeleteImpactType(ctx, impactType)
+	return err
+}
+
 // GetIncidents converts echo context to params.
 func (w *ServerInterfaceWrapper) GetIncidents(ctx echo.Context) error {
 	var err error
@@ -204,6 +245,22 @@ func (w *ServerInterfaceWrapper) CreateIncident(ctx echo.Context) error {
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.CreateIncident(ctx)
+	return err
+}
+
+// DeleteIncident converts echo context to params.
+func (w *ServerInterfaceWrapper) DeleteIncident(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "incidentId" -------------
+	var incidentId string
+
+	err = runtime.BindStyledParameterWithLocation("simple", false, "incidentId", runtime.ParamLocationPath, ctx.Param("incidentId"), &incidentId)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter incidentId: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.DeleteIncident(ctx, incidentId)
 	return err
 }
 
@@ -271,11 +328,14 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 
 	router.GET(baseURL+"/components", wrapper.GetComponents)
 	router.POST(baseURL+"/components", wrapper.CreateComponent)
+	router.DELETE(baseURL+"/components/:componentId", wrapper.DeleteComponent)
 	router.GET(baseURL+"/components/:componentId", wrapper.GetComponent)
 	router.GET(baseURL+"/impacttypes", wrapper.GetImpacttypes)
 	router.POST(baseURL+"/impacttypes", wrapper.CreateImpactType)
+	router.DELETE(baseURL+"/impacttypes/:impactType", wrapper.DeleteImpactType)
 	router.GET(baseURL+"/incidents", wrapper.GetIncidents)
 	router.POST(baseURL+"/incidents", wrapper.CreateIncident)
+	router.DELETE(baseURL+"/incidents/:incidentId", wrapper.DeleteIncident)
 	router.GET(baseURL+"/incidents/:incidentId", wrapper.GetIncident)
 	router.GET(baseURL+"/phases", wrapper.GetPhases)
 	router.PUT(baseURL+"/phases", wrapper.PutPhases)
@@ -285,21 +345,22 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/8xXUY+jNhD+K5bbh1ZiA0n6Ut7uovaEeupFzfWlp31w8JD1CWyfbdqiiP9e2SYBAktI",
-	"c7daaR8Aj2e+mfm+mc0Rp6KQggM3GsdHrNMnKIh73JwO7ItUQoIyDNwRyTJIDdC3lX1jBgr3+XsFGY7x",
-	"d2HrM2wchgnFdYBNJQHHmChFKvtOmZY5qX4nBVgHzbE2ivGDPWfUflZA6AeeVzg2qoRgaJaTPeRXIbz3",
-	"VnUdYAVfSqaA4viTjdEHcvYXdBN9PMcV+8+QGhs3oaOoE54yOlE4fWfV9nAg/I1znwlVEINjTImBB8Mc",
-	"/AEgCjpVTBom+Chg4BTohENe5jnZ5/BsA2b2iRWSpOaj+3wl8aaESXujDrB8Inr21a0ztuVjJh+nVylt",
-	"lje0o3H9p7s3bM0Ys3z0fg/ayMGZEr3qnFIdJd2wNFMk3J5q9qxFk82ArKkCYiZ5MXBp4F8zEuuiLs4q",
-	"6PgfS/P9WdOEUmbLRvJtD98wet+HDct4Jpyt5wDebXZoZ4gpNdqSA6A32wQH+G9Q2mkDLxeR9SQkcCIZ",
-	"jvF6ES1Wth/EPLmoYX9gHsAlbHERC9KOBPwOzKa1sslrKbj2sFdR5KoruGlmBJEyZ6m7Hn7WXqOecrOZ",
-	"2Q7rISkvBwD+8Jv/KoUeAb9xbWkd+t6BNm8FrW5CPhNw7fnRK9HypkCXdBtk7HOijom6LAqiqvNXRBCH",
-	"f1DaARR0uxwez88JrWf13PFFkQIMKI3jT0fMLArLITtN3bbDHa+4qw8/O59P7vFOPs3uyihtuvV7BwZp",
-	"CSnLWNrWD+0rxHypQz/SbAaTYkk6Zi+hlvHt8jVkk3Rn+LfQzRj01yEg32tkPCTb/AbqdOvPRgPN9BHs",
-	"DFEGiQzZ3YMya4mMQF9KUBXKhEI//PHrZr1e//yjXaX2hjtq9aatg0mlUchImdslt4pWq4do+RAtPy6j",
-	"2P0tomX0Fw5mLcI6uET/C6f3YAdO5yP/6R7kjy+pv9mqu5w6OdOOCy3FrunyFPHbqvLVaLHF0xVieDw9",
-	"XtlknXJdX2Stz1ezx7r9uG2NnZLpbjH3v/jkFNt6i5fUTvvzZu7aKkewb8su9v8njK8Du76zeI2/vRA5",
-	"ED6r8T3JnEaKb/bCQfovAAD//weRkBYeEQAA",
+	"H4sIAAAAAAAC/9RYwY7bNhD9FYLtoQW0luztpbolbhsYDRqjm14a7IEWR7sMJJIhqbaC4X8vSMoSZWll",
+	"uZtsHWAPEkXNvHnz5onrPc5EKQUHbjRO91hnj1ASd7k+PrA3UgkJyjBwj0ieQ2aAvq7tHTNQuuVvFeQ4",
+	"xd/EXcy4CRhvKD5E2NQScIqJUqS295RpWZD6N1KCDdA81kYx/mCfM2qXFRD6jhc1To2qIBpuK8gOirMQ",
+	"3vpdh0OEFXyqmAKK0w82Rx9IGy8KC71v84rdR8iMzbuho6g3PGN0gjj9TNZ28ED4Kxc+F6okBqeYEgM3",
+	"hjn4A0AUdKaYNEzwUcDAKdCJgLwqCrIr4MkGzOwTKyXJzHu3fKbwhsJN98YhwvKR6Nmvbt1mSx8zxbi8",
+	"KmmrvKAdTeg/3HvD1owpy2fv96DLHLWS6LFzLHVUdENqpkS4PXL25I6mmoFYMwXETOpiENLAP2Yk1wkv",
+	"blcUxB8r820704RSZmkjxbaHb5i9H8OmZTwXbq/XAL5b36E7Q0yl0ZY8AHq13eAI/wVKu9nAy0ViIwkJ",
+	"nEiGU3y7SBYr2w9iHl3WuG+YD+AKtriIBWktAb8Bs+522eK1FFx72KskcewKbhqPIFIWLHOvxx+1n1Ev",
+	"udnK7Mx6KMpTA8DvfvWrUugR8GvXli6g7x1o81rQ+iLkMwEfvD56FC0vSnQqt0HFvibqlKirsiSqblcR",
+	"QRz+RlkAKAq7HO/b6w092HQUCvAD02fuJ7ceMieJIiUYUBqnH/aYWSxWSdZT3TcPB7FxOCXeQZ8u8f6Z",
+	"qmri7YQogPAnVRLS5ctDJKQqOj8AV03DbImeZecNGKQlZCxnWccQ2tWIed3F3t9tBZPOsQm2vYR1jH9q",
+	"P4eHbMIP2pcwkTHo1+EmvtfIeEj95sf77ks/w096LJ6fJHZK+vggXUzr/2k4QzYbhNOD1G4a8NZPfGeI",
+	"MkjkyB5rUG53IiPQpwpUjXKh0He//7K+vb398Xt7SrNvuEcd59oGmKSbQk6qwp6fVslqdZMsb5Ll+2WS",
+	"ur9Fskz+xNGsM9YhOkX/M6fPwQ6czkf+w3OQ37+km832sFMPL5h2Wugkds7ljhm/rMddjbN1eMJBjPfH",
+	"y1mHpIC0GZbWRv5qjkgskOE5f7pmDuYq87Lj0bGY8HTk/uGd9POt3/GSLtL9hjD3OFSNYN9WIfb/ZhGf",
+	"B/bh5UeiZx5Hc/XNXjhI/wYAAP//G/i7qIMUAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file


### PR DESCRIPTION
Define write operations for the status page Open API spec, mentioned in SovereignCloudStack/issues#281.

Includes:
- Create operations (`POST`) for:
  -  `PhaseList`
  - `ImpactType`
  - `Component`
  - `Incident`
  - `IncidentUpdate`
- Update opertations (`PATCH`) for:
  - `ImpactType`
  - `Component`
  - `Incident`
  - `IncidentUpdate`
- Delete operations (`DELETE`) for:
  -  `ImpactType`
  - `Components`
  - `Incident`
  - `IncidentUpdate`

`Phase`s are now handled as `PhaseList`, these use a generation system, to allow new lists to be created, for CUD operations on `Phases` without losing the reference.

The `IncidentUpdate`s are now handled as a real sub resource to incidents. 

`Impact`s are "helper" objects to connect `Incident`s and `Component`s and do not represent a standalone resource.